### PR TITLE
Co-registered S1 SLC schema

### DIFF
--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -1,0 +1,34 @@
+runconfig:
+   name: cslc_s1_workflow_default
+
+   groups:
+       pge_name_group:
+           pge_name: CSLC_S1_PGE
+
+       input_file_group:
+           # Required if burst_id is not provided. List of reference and secondary S1 ZIP files
+           input_file_path:
+           # List of reference and secondary orbit file
+           orbit_file_path:
+           # List of unique burst IDs. Required if input_file_path is not provided
+           burst_id:
+
+       dynamic_ancillary_file_group:
+           # Digital Elevation Model
+           dem_file:
+
+       product_path_group:
+           # Directory where PGE will place results
+           product_path:
+           # Directory where SAS can write temporary data
+           scratch_path:
+           # Intermediate file name. SAS writes the output to this file.
+           # PGE ay rename the product according to file naming convention
+           sas_output_file:
+
+       primary_executable:
+           product_type: CSLC_S1
+
+       processing:
+           rdr2geo:
+               lines_per_block: 1000

--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -14,7 +14,7 @@ runconfig:
            burst_id:
            # Options for reference burst
            reference_burst:
-               # Required. Flag indicating reference burst
+               # Required. Flag indicating reference burst. If True, the input zip file is a reference date
                is_reference: True
                # File path to reference burst to which coregister secondary burst.
                # Only used if the flag is_reference is set to False.

--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -14,7 +14,10 @@ runconfig:
            burst_id:
            # Options for reference burst
            reference_burst:
+               # Required. Flag indicating reference burst
                is_reference: True
+               # File path to reference burst to which coregister secondary burst.
+               # Only used if the flag is_reference is set to False.
                file_path:
 
        dynamic_ancillary_file_group:

--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -6,12 +6,16 @@ runconfig:
            pge_name: CSLC_S1_PGE
 
        input_file_group:
-           # Required. List of reference and secondary S1 ZIP files
-           input_file_path:
-           # List of reference and secondary orbit file
+           # Required. List of SAFE files (min=1)
+           safe_file_path:
+           # Required. List of orbit (EOF) files (min=1)
            orbit_file_path:
-           # List of unique burst IDs. Required if input_file_path is not provided
+           # List of (unique) burst IDs to process
            burst_id:
+           # Options for reference burst
+           reference_burst:
+               is_reference: False
+               file_path:
 
        dynamic_ancillary_file_group:
            # Digital Elevation Model
@@ -32,3 +36,10 @@ runconfig:
        processing:
            rdr2geo:
                lines_per_block: 1000
+
+           geo2rdr:
+               lines_per_block: 1000
+
+           resample:
+               lines_per_block: 1000
+

--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -6,7 +6,7 @@ runconfig:
            pge_name: CSLC_S1_PGE
 
        input_file_group:
-           # Required if burst_id is not provided. List of reference and secondary S1 ZIP files
+           # Required. List of reference and secondary S1 ZIP files
            input_file_path:
            # List of reference and secondary orbit file
            orbit_file_path:

--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -14,7 +14,7 @@ runconfig:
            burst_id:
            # Options for reference burst
            reference_burst:
-               is_reference: False
+               is_reference: True
                file_path:
 
        dynamic_ancillary_file_group:

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -11,7 +11,7 @@ runconfig:
            # Required. List of orbit (EOF) files
            orbit_file_path: list(str(), min=1)
            # List of (unique) burst ID to process
-           burst_id: list(str(), min=0, max=27, required=False)
+           burst_id: list(str(), min=1, required=False)
            # Reference burst options
            reference_burst: include('reference_burst_options', required=False)
 

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -48,7 +48,8 @@ runconfig:
 
 # Group of processing options
 reference_burst_options:
-    # Required. Flag indicating reference burst
+    # Required. Flag indicating reference burst.
+    # If True, the input zip file is a reference date
     is_reference: bool()
     # File path to reference burst to which coregister secondary burst.
     # Only used if the flag is_reference is set to False.

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -6,12 +6,14 @@ runconfig:
            pge_name: enum('CSLC_S1_PGE')
 
         input_file_group:
-           # Required. List of reference and secondary S1 ZIP files
-           input_file_path: list(str(), min=2, max=2)
-           # List of reference and secondary orbit file
-           orbit_file_path: list(str(), min=2, max=2, required=False)
-           # List of unique burst IDs. Required if input_file_path is not provided.
+           # Required. List of SAFE files (min=1)
+           safe_file_path: list(str(), min=1)
+           # Required. List of orbit (EOF) files
+           orbit_file_path: list(str(), min=1)
+           # List of (unique) burst ID to process
            burst_id: list(str(), min=0, max=27, required=False)
+           # Reference burst options
+           reference_burst: include('reference_burst_options', required=False)
 
         dynamic_ancillary_file_group:
            # Digital Elevation Model.
@@ -23,7 +25,7 @@ runconfig:
            # Directory where SAS can write temporary data
            scratch_path: str()
            # Intermediate file name. SAS writes the output to this file.
-           # PGE ay rename the product according to file naming convention
+           # PGE may rename the product according to file naming convention
            sas_output_file: str()
 
         primary_executable:
@@ -37,15 +39,36 @@ runconfig:
            # Options to run rdr2geo
            rdr2geo: include('rdr2geo_options', required=False)
 
+           # Options to run geo2rdr
+           geo2rdr: include('rdr2geo_geo2rdr_shared_options', required=False)
+
+           # Options to run resample
+           resample: include('resample_options', required=False)
+
 
 # Group of processing options
+reference_burst_options:
+    # Required. Flag indicating reference burst
+    is_reference: bool()
+    # File path to reference burst
+    file_path: str(required=False)
+
+rdr2geo_geo2rdr_shared_options:
+   # Convergence threshold for rdr2geo algorithm
+   threshold: num(min=0, required=False)
+   # Maximum number of iterations
+   numiter: int(min=1, required=False)
+   # Lines per block to process in batch
+   lines_per_block: int(min=1, required=False)
+
 rdr2geo_options:
-    # Convergence threshold for rdr2geo algorithm
-    threshold: num(min=0, required=False)
-    # Maximum number of iterations
-    numiter: int(min=1, required=False)
-    # Secondary number of iterations
-    extraiter: int(min=1, required=False)
-    # Lines per block to process in batch
-    lines_per_block: int(min=1, required=False)
+   # rdr2geo and geo2rdr shared options
+   include('rdr2geo_geo2rdr_shared_options', required=False)
+   # Secondary number of iterations
+   extraiter: int(min=1, required=False)
+
+resample_options:
+   # Lines per block to process in batch
+   lines_per_block: int(min=1, required=False)
+
 

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -6,8 +6,8 @@ runconfig:
            pge_name: enum('CSLC_S1_PGE')
 
         input_file_group:
-           # Required if burst_id is not provided. List of reference and secondary S1 ZIP files
-           input_file_path: list(str(), min=2, max=2, required=False)
+           # Required. List of reference and secondary S1 ZIP files
+           input_file_path: list(str(), min=2, max=2)
            # List of reference and secondary orbit file
            orbit_file_path: list(str(), min=2, max=2, required=False)
            # List of unique burst IDs. Required if input_file_path is not provided.

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -50,7 +50,8 @@ runconfig:
 reference_burst_options:
     # Required. Flag indicating reference burst
     is_reference: bool()
-    # File path to reference burst
+    # File path to reference burst to which coregister secondary burst.
+    # Only used if the flag is_reference is set to False.
     file_path: str(required=False)
 
 rdr2geo_geo2rdr_shared_options:

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -1,0 +1,51 @@
+runconfig:
+    name: str()
+
+    groups:
+        pge_name_group:
+           pge_name: enum('CSLC_S1_PGE')
+
+        input_file_group:
+           # Required if burst_id is not provided. List of reference and secondary S1 ZIP files
+           input_file_path: list(str(), min=2, max=2, required=False)
+           # List of reference and secondary orbit file
+           orbit_file_path: list(str(), min=2, max=2, required=False)
+           # List of unique burst IDs. Required if input_file_path is not provided.
+           burst_id: list(str(), min=0, max=27, required=False)
+
+        dynamic_ancillary_file_group:
+           # Digital Elevation Model.
+           dem_file: include(str(), required=False)
+
+        product_path_group:
+           # Directory where PGE will place results
+           product_path: str()
+           # Directory where SAS can write temporary data
+           scratch_path: str()
+           # Intermediate file name. SAS writes the output to this file.
+           # PGE ay rename the product according to file naming convention
+           sas_output_file: str()
+
+        primary_executable:
+           product_type: enum('CSLC_S1')
+
+        # This section includes parameters to tweak the workflow
+        processing:
+           # Polarization to process. If not set, process all polarizations for that burst
+           polarization: any(list('HH', 'HV', 'VH', 'VV'), min=1, max=4), str(min=2, max=2), required=False)
+
+           # Options to run rdr2geo
+           rdr2geo: include('rdr2geo_options', required=False)
+
+
+# Group of processing options
+rdr2geo_options:
+    # Convergence threshold for rdr2geo algorithm
+    threshold: num(min=0, required=False)
+    # Maximum number of iterations
+    numiter: int(min=1, required=False)
+    # Secondary number of iterations
+    extraiter: int(min=1, required=False)
+    # Lines per block to process in batch
+    lines_per_block: int(min=1, required=False)
+


### PR DESCRIPTION
This (small) PR introduces a schema for the S1-A/B co-registered SLC workflow. Some of the decisions made in designing the schema will drive/affect the design of the workflow.

Some food for thoughts:
1. As an input file, the workflow should take the path to reference and secondary granules. If a list of `burst_id` is provided, the workflow will process only that burst IDs. If `burst_id` is empty, all the bursts in the zip files are processed.
2. Orbits are not required. If left empty, the workflow will download the required orbits (working on a script)
3. DEM file is not required. If not assigned, DEM should be downloaded automatically. Thinking to write a wrapper to download the Copernicus DEM.

Please, double-check if the selected directory structure makes sense.


