### PR TITLE
Address S1 reader name change for rdr2geo workflow

### DIFF
--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -11,9 +11,9 @@ from ruamel.yaml import YAML
 
 from compass.utils import helpers
 from compass.utils.wrap_namespace import wrap_namespace
-from sentinel1_reader.sentinel1_burst_slc import Sentinel1BurstSlc
-from sentinel1_reader.sentinel1_orbit_reader import get_swath_orbit_file_from_list
-from sentinel1_reader.sentinel1_reader import burst_from_zip
+from s1reader.s1_burst_slc import Sentinel1BurstSlc
+from s1reader.s1_orbit import get_orbit_file_from_list
+from s1reader.s1_reader import burst_from_zip
 
 
 def validate_group_dict(group_cfg: dict) -> None:
@@ -115,7 +115,7 @@ def load_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
         zip_list = zip(cycle(pols), i_subswaths)
 
         # find orbit file
-        orbit_path = get_swath_orbit_file_from_list(
+        orbit_path = get_orbit_file_from_list(
             safe_file,
             cfg.input_file_group.orbit_file_path)
 


### PR DESCRIPTION
This PR accounts for the name changes lately merged in the s1-reader repo.
The changes mainly pertain to the `runconfig.py` and should avoid COMPASS to break when using the `rdr2geo.py` (or the wrapper `cslc.py`) when using the latest version of the Sentinel1-A/B reader.

If merged quickly into the main branch, the PR should equivalently avoid any issue for other downstream modules available in this PR here https://github.com/opera-adt/COMPASS/pull/9 

When pulling the latest s1-reader changes, don't forget to manually change the name of your reader repo on your forked branch on the web github. Instructions are reported here:  https://docs.github.com/en/repositories/creating-and-managing-repositories/renaming-a-repository