### PR TITLE
Logging formatting (pyre 1.11.0)

### DIFF
--- a/.idea/COMPASS.iml
+++ b/.idea/COMPASS.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="NUMPY" />
+    <option name="myDocStringFormat" value="NumPy" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 2.7 (COMPASS)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/COMPASS.iml" filepath="$PROJECT_DIR$/.idea/COMPASS.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/compass/rdr2geo.py
+++ b/src/compass/rdr2geo.py
@@ -17,9 +17,10 @@ from compass.utils.yaml_argparse import YamlArgparse
 def run(cfg):
     '''run rdr2geo with provided runconfig'''
     info_channel = journal.info("rdr2geo.run")
+    logging = Logger(channel=info_channel)
 
     t_start = time.time()
-    info_channel.log("starting rdr2geo")
+    logging.info('rdr2geo', 100, "starting rdr2geo")
 
     # common rdr2geo inits
     dem_raster = isce3.io.Raster(cfg.dem)
@@ -95,7 +96,7 @@ def run(cfg):
         output_vrt.set_epsg(rdr2geo_obj.epsg_out)
 
     dt = time.time() - t_start
-    info_channel.log(f"rdr2geo successfully ran in {dt:.3f} seconds")
+    logging.info("rdr2geo", 100, f"rdr2geo successfully ran in {dt:.3f} seconds")
 
 
 if __name__ == "__main__":

--- a/src/compass/rdr2geo.py
+++ b/src/compass/rdr2geo.py
@@ -17,10 +17,10 @@ from compass.utils.yaml_argparse import YamlArgparse
 def run(cfg):
     '''run rdr2geo with provided runconfig'''
     info_channel = journal.info("rdr2geo.run")
-    logging = Logger(channel=info_channel)
+    logging = Logger(channel=info_channel, workflow='CSLC')
 
     t_start = time.time()
-    logging.info('rdr2geo', 100, "starting rdr2geo")
+    logging.info('rdr2geo.py', 9999, "starting rdr2geo")
 
     # common rdr2geo inits
     dem_raster = isce3.io.Raster(cfg.dem)
@@ -96,7 +96,7 @@ def run(cfg):
         output_vrt.set_epsg(rdr2geo_obj.epsg_out)
 
     dt = time.time() - t_start
-    logging.info("rdr2geo", 100, f"rdr2geo successfully ran in {dt:.3f} seconds")
+    logging.info("rdr2geo.py", 9999, f"rdr2geo successfully ran in {dt:.3f} seconds")
 
 
 if __name__ == "__main__":

--- a/src/compass/rdr2geo.py
+++ b/src/compass/rdr2geo.py
@@ -9,6 +9,7 @@ import isce3
 import journal
 from osgeo import gdal
 
+from compass.utils.logger import Logger
 from compass.utils.runconfig import RunConfig
 from compass.utils.yaml_argparse import YamlArgparse
 

--- a/src/compass/utils/defaults/cslc_s1.yaml
+++ b/src/compass/utils/defaults/cslc_s1.yaml
@@ -46,6 +46,10 @@ runconfig:
            resample:
                lines_per_block: 1000
 
+       logging:
+           path:
+           write_mode: 'w'
+
        worker:
            # OPTIONAL - To prevent downloading DEM / other data automatically. Default True
            internet_access: False

--- a/src/compass/utils/error_codes.py
+++ b/src/compass/utils/error_codes.py
@@ -1,0 +1,107 @@
+"""
+==============
+error_codes.py
+==============
+Error codes for use with OPERA PGEs.
+"""
+
+from enum import IntEnum, auto, unique
+
+CODES_PER_RANGE = 1000
+"""Number of error codes allocated to each range"""
+
+INFO_RANGE_START = 0
+"""Starting value for the Info code range"""
+
+DEBUG_RANGE_START = INFO_RANGE_START + CODES_PER_RANGE
+"""Starting value for the Debug code range"""
+
+WARNING_RANGE_START = DEBUG_RANGE_START + CODES_PER_RANGE
+"""Starting value for the Warning code range"""
+
+CRITICAL_RANGE_START = WARNING_RANGE_START + CODES_PER_RANGE
+"""Starting value for the Critical code range"""
+
+
+@unique
+class ErrorCode(IntEnum):
+    """
+    Error codes for OPERA PGEs.
+    Each code is combined with the designated error code offset defined by
+    the RunConfig to determine the final, logged error code.
+    """
+
+    # Info - 0 to 999
+    OVERALL_SUCCESS = INFO_RANGE_START
+    LOG_FILE_CREATED = auto()
+    LOADING_RUN_CONFIG_FILE = auto()
+    VALIDATING_RUN_CONFIG_FILE = auto()
+    LOG_FILE_INIT_COMPLETE = auto()
+    CREATING_WORKING_DIRECTORY = auto()
+    DIRECTORY_SETUP_COMPLETE = auto()
+    MOVING_LOG_FILE = auto()
+    MOVING_OUTPUT_FILE = auto()
+    SUMMARY_STATS_MESSAGE = auto()
+    RUN_CONFIG_FILENAME = auto()
+    PGE_NAME = auto()
+    SCHEMA_FILE = auto()
+    INPUT_FILE = auto()
+    PROCESSING_INPUT_FILE = auto()
+    USING_CONFIG_FILE = auto()
+    CREATED_SAS_CONFIG = auto()
+    CREATING_OUTPUT_FILE = auto()
+    CREATING_CATALOG_METADATA = auto()
+    CREATING_ISO_METADATA = auto()
+    SAS_PROGRAM_STARTING = auto()
+    SAS_PROGRAM_COMPLETED = auto()
+    QA_SAS_PROGRAM_STARTING = auto()
+    QA_SAS_PROGRAM_COMPLETED = auto()
+    QA_SAS_PROGRAM_DISABLED = auto()
+    RENDERING_ISO_METADATA = auto()
+    CLOSING_LOG_FILE = auto()
+
+    # Debug - 1000 – 1999
+    CONFIGURATION_DETAILS = DEBUG_RANGE_START
+    PROCESSING_DETAILS = auto()
+    SAS_EXE_COMMAND_LINE = auto()
+    SAS_QA_COMMAND_LINE = auto()
+
+    # Warning - 2000 – 2999
+    DATE_RANGE_MISSING = WARNING_RANGE_START
+    NO_RENAME_FUNCTION_FOR_EXTENSION = auto()
+    ISO_METADATA_CANT_RENDER_ONE_VARIABLE = auto()
+    LOGGING_REQUESTED_SEVERITY_NOT_FOUND = auto()
+    LOGGING_SOURCE_FILE_DOES_NOT_EXIST = auto()
+    LOGGING_COULD_NOT_INCREMENT_SEVERITY = auto()
+    LOGGING_RESYNC_FAILED = auto()
+
+    # Critical - 3000 to 3999
+    RUN_CONFIG_VALIDATION_FAILED = CRITICAL_RANGE_START
+    DIRECTORY_CREATION_FAILED = auto()
+    SAS_CONFIG_CREATION_FAILED = auto()
+    CATALOG_METADATA_CREATION_FAILED = auto()
+    LOG_FILE_CREATION_FAILED = auto()
+    INPUT_NOT_FOUND = auto()
+    OUTPUT_NOT_FOUND = auto()
+    INVALID_INPUT = auto()
+    INVALID_OUTPUT = auto()
+    INVALID_CATALOG_METADATA = auto()
+    FILE_MOVE_FAILED = auto()
+    FILENAME_VIOLATES_NAMING_CONVENTION = auto()
+    SAS_PROGRAM_NOT_FOUND = auto()
+    SAS_PROGRAM_FAILED = auto()
+    QA_SAS_PROGRAM_NOT_FOUND = auto()
+    QA_SAS_PROGRAM_FAILED = auto()
+    ISO_METADATA_TEMPLATE_NOT_FOUND = auto()
+    ISO_METADATA_GOT_SOME_RENDERING_ERRORS = auto()
+    ISO_METADATA_RENDER_FAILED = auto()
+    SAS_OUTPUT_FILE_HAS_MISSING_DATA = auto()
+
+    @classmethod
+    def describe(cls):
+        """
+        Provides a listing of the available error codes and their associated
+        integer values.
+        """
+        for name, member in cls.__members__.items():
+            print(f'{name}: {member.value}')

--- a/src/compass/utils/error_codes.py
+++ b/src/compass/utils/error_codes.py
@@ -1,8 +1,6 @@
 """
-==============
-error_codes.py
-==============
-Error codes for use with OPERA PGEs.
+Error codes (from OPERA PGE)
+TO DO: Add ISCE3 specific error codes
 """
 
 from enum import IntEnum, auto, unique

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -5,6 +5,8 @@ import os
 import journal
 from osgeo import gdal
 
+from compass.utils.logger import Logger
+
 WORKFLOW_SCRIPTS_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -18,11 +20,11 @@ def check_file_path(file_path: str) -> None:
     polarizations : list[str]
         Path to file to be checked
     """
-    error_channel = journal.error('helpers.check_file_path')
+    channel = journal.error('helpers.check_file_path')
+    logging = Logger(channel=channel, workflow='CSLC')
     if not os.path.isfile(file_path):
         err_str = f'{file_path} not found'
-        error_channel.log(err_str)
-        raise FileNotFoundError(err_str)
+        logging.critical('helpers.py', 9999, err_str)
 
 
 def get_file_polarization_mode(file_path: str) -> str:
@@ -92,7 +94,8 @@ def check_write_dir(dst_path: str):
     if not dst_path:
         dst_path = '.'
 
-    error_channel = journal.error('helpers.check_write_dir')
+    channel = journal.error('helpers.check_write_dir')
+    logging = Logger(channel=channel, workflow='CSLC')
 
     # check if scratch path exists
     dst_path_ok = os.path.isdir(dst_path)
@@ -102,15 +105,13 @@ def check_write_dir(dst_path: str):
             os.makedirs(dst_path, exist_ok=True)
         except OSError:
             err_str = f"Unable to create {dst_path}"
-            error_channel.log(err_str)
-            raise OSError(err_str)
+            logging.critical('helpers.py', 9999, err_str)
 
     # check if path writeable
     write_ok = os.access(dst_path, os.W_OK)
     if not write_ok:
         err_str = f"{dst_path} scratch directory lacks write permission."
-        error_channel.log(err_str)
-        raise PermissionError(err_str)
+        logging.critical('helpers.py', 9999, err_str)
 
 
 def check_dem(dem_path: str):
@@ -121,10 +122,11 @@ def check_dem(dem_path: str):
     dem_path : str
         File path to DEM for which to check GDAL-compatibility
     """
-    error_channel = journal.error('helpers.check_dem')
+    channel = journal.error('helpers.check_dem')
+    logging = Logger(channel=channel, workflow='CSLC')
     try:
         gdal.Open(dem_path, gdal.GA_ReadOnly)
     except:
         err_str = f'{dem_path} cannot be opened by GDAL'
-        error_channel.log(err_str)
+        logging.critical('helpers.py', 9999, err_str)
         raise ValueError(err_str)

--- a/src/compass/utils/logger.py
+++ b/src/compass/utils/logger.py
@@ -1,0 +1,141 @@
+import datetime
+import inspect
+import time
+import journal
+from os.path import basename
+
+from compass.utils import error_codes
+from .error_codes import ErrorCode
+
+def get_severity_from_error_code(error_code):
+    """
+    Determines the log level (Critical, Warning, Info, or Debug) based on the
+    provided error code.
+    Parameters
+    ----------
+    error_code : int or ErrorCode
+        The error code to map to a severity level.
+    Returns
+    -------
+    severity : str
+        The severity level associated to the provided error code.
+    """
+    # TODO: constants for max codes and severity strings
+    error_code_offset = error_code % 10000
+
+    if error_code_offset < error_codes.DEBUG_RANGE_START:
+        return "Info"
+
+    if error_code_offset < error_codes.WARNING_RANGE_START:
+        return "Debug"
+
+    if error_code_offset < error_codes.CRITICAL_RANGE_START:
+        return "Warning"
+
+    return "Critical"
+
+class Logger:
+    '''
+    Class to handle log of info and error messages
+    '''
+
+    LOGGER_CODE_BASE = 900000
+    QA_LOGGER_CODE_BASE = 800000
+
+    def __init__(self, workflow=None, error_code_base=None,
+                 channel=None):
+        self.start_time = time.monotonic()
+        self.log_count_by_severity = self._make_blank_log_count_by_severity_dict()
+        self.channel = channel
+
+        if not channel:
+            self.channel = journal.info('logger.Logger')
+        self.workflow = (workflow
+                         if workflow else f"{basename(__file__)}")
+        self.error_code_base = (error_code_base
+                                if error_code_base else Logger.LOGGER_CODE_BASE)
+
+    def get_workflow(self):
+        return self.workflow
+
+    def set_workflow(self, workflow):
+        self.workflow = workflow
+
+    def get_error_code_base(self):
+        return self.error_code_base
+
+    def set_error_code_base(self, error_code_base: int):
+        self.error_code_base = error_code_base
+
+    @staticmethod
+    def _make_blank_log_count_by_severity_dict():
+        return {
+            "Debug": 0,
+            "Info": 0,
+            "Warning": 0,
+            "Critical": 0
+        }
+
+    def get_log_count_by_severity(self):
+        return self.log_count_by_severity.copy()
+
+    def increment_log_count_by_severity(self, severity):
+        try:
+            severity = severity.title()
+            count = 1 + self.log_count_by_severity[severity]
+            self.log_count_by_severity[severity] = count
+        except:
+            self.warning("Logger", ErrorCode.LOGGING_COULD_NOT_INCREMENT_SEVERITY,
+                         f"Could not increment severity level: '{severity}")
+
+    def write(self, severity, module, error_code_offset, description,
+              additional_back_frames=0):
+        severity = severity.title()
+        self.increment_log_count_by_severity(severity)
+
+        caller = inspect.currentframe().f_back
+
+        for _ in range(additional_back_frames):
+            caller = caller.f_back
+
+        location = caller.f_code.co_filename + ':' + str(caller.f_lineno)
+        workflow = self.workflow
+        error_code_base = self.error_code_base
+
+        now_tag = datetime.datetime.now()
+        time_tag = now_tag.strftime("%Y-%m-%dT%H:%M:%S.%f")
+        message = f'{time_tag}, {severity}, {workflow}, {module}, ' \
+                  f'{str(error_code_base + error_code_offset)},' \
+                  f'{location}, {description}'
+
+        self.channel.log(message)
+
+    def info(self, module, error_code_offset, description):
+        self.write("Info", module, error_code_offset, description,
+                   additional_back_frames=1)
+
+    def debug(self, module, error_code_offset, description):
+        self.write("Debug", module, error_code_offset, description,
+                   additional_back_frames=1)
+
+    def warning(self, module, error_code_offset, description):
+        self.write("Warning", module, error_code_offset, description,
+                   additional_back_frames=1)
+
+    def critical(self, module, error_code_offset, description):
+        self.write("Critical", module, error_code_offset, description,
+                   additional_back_frames=1)
+        raise RuntimeError(description)
+
+    def log(self, module, error_code_offset, description,
+            additional_back_frames=0):
+        severity = get_severity_from_error_code(error_code_offset)
+        self.write(severity, module, error_code_offset, description,
+                   additional_back_frames=additional_back_frames + 1)
+
+
+
+
+
+
+

--- a/src/compass/utils/logger.py
+++ b/src/compass/utils/logger.py
@@ -50,8 +50,7 @@ class Logger:
 
         if not channel:
             self.channel = journal.info('logger.Logger')
-        self.workflow = (workflow
-                         if workflow else f"{basename(__file__)}")
+        self.workflow = "CSLC"
         self.error_code_base = (error_code_base
                                 if error_code_base else Logger.LOGGER_CODE_BASE)
 
@@ -105,7 +104,7 @@ class Logger:
         now_tag = datetime.datetime.now()
         time_tag = now_tag.strftime("%Y-%m-%dT%H:%M:%S.%f")
         message = f'{time_tag}, {severity}, {workflow}, {module}, ' \
-                  f'{str(error_code_base + error_code_offset)},' \
+                  f'{str(error_code_base + error_code_offset)}, ' \
                   f'{location}, {description}'
 
         self.channel.log(message)
@@ -132,10 +131,4 @@ class Logger:
         severity = get_severity_from_error_code(error_code_offset)
         self.write(severity, module, error_code_offset, description,
                    additional_back_frames=additional_back_frames + 1)
-
-
-
-
-
-
 

--- a/src/compass/utils/logger.py
+++ b/src/compass/utils/logger.py
@@ -2,10 +2,10 @@ import datetime
 import inspect
 import time
 import journal
-from os.path import basename
 
 from compass.utils import error_codes
 from .error_codes import ErrorCode
+
 
 def get_severity_from_error_code(error_code):
     """
@@ -34,6 +34,7 @@ def get_severity_from_error_code(error_code):
 
     return "Critical"
 
+
 class Logger:
     '''
     Class to handle log of info and error messages
@@ -42,32 +43,74 @@ class Logger:
     LOGGER_CODE_BASE = 900000
     QA_LOGGER_CODE_BASE = 800000
 
-    def __init__(self, workflow=None, error_code_base=None,
-                 channel=None):
+    def __init__(self, workflow=None,
+                 error_code_base=None, channel=None):
+        '''
+        Constructor for Logger class
+
+        Parameters
+        ----------
+        workflow: str
+            Name of the workflow for which to use logging
+        error_code_base: int
+            Error code base
+        channel: journal.info, journal.error
+            journal channel object
+        '''
         self.start_time = time.monotonic()
         self.log_count_by_severity = self._make_blank_log_count_by_severity_dict()
         self.channel = channel
 
         if not channel:
             self.channel = journal.info('logger.Logger')
-        self.workflow = "CSLC"
+        self.workflow = workflow
         self.error_code_base = (error_code_base
                                 if error_code_base else Logger.LOGGER_CODE_BASE)
 
     def get_workflow(self):
+        '''
+        Get workflow name
+        '''
         return self.workflow
 
     def set_workflow(self, workflow):
+        '''
+        Set workflow name to use for logging
+
+        Parameters
+        ----------
+        workflow: str
+            Workflow name to use for logging
+        '''
         self.workflow = workflow
 
     def get_error_code_base(self):
+        '''
+        Get error code base
+        '''
         return self.error_code_base
 
     def set_error_code_base(self, error_code_base: int):
+        '''
+        Set error code base
+
+        Parameters
+        ----------
+        error_code_base: int
+            Error code base
+        '''
         self.error_code_base = error_code_base
 
     @staticmethod
     def _make_blank_log_count_by_severity_dict():
+        '''
+        Return blank log count by severity dictionary
+
+        Returns
+        -------
+        dict: dict
+            Return log count by severity dictionary
+        '''
         return {
             "Debug": 0,
             "Info": 0,
@@ -76,19 +119,47 @@ class Logger:
         }
 
     def get_log_count_by_severity(self):
+        '''
+        Get log count by severity
+        '''
         return self.log_count_by_severity.copy()
 
     def increment_log_count_by_severity(self, severity):
+        '''
+        Increment log count by severity
+
+        Parameters
+        ----------
+        severity: str
+            Severity of the error to increment
+        '''
         try:
             severity = severity.title()
             count = 1 + self.log_count_by_severity[severity]
             self.log_count_by_severity[severity] = count
         except:
-            self.warning("Logger", ErrorCode.LOGGING_COULD_NOT_INCREMENT_SEVERITY,
+            self.warning("Logger",
+                         ErrorCode.LOGGING_COULD_NOT_INCREMENT_SEVERITY,
                          f"Could not increment severity level: '{severity}")
 
     def write(self, severity, module, error_code_offset, description,
               additional_back_frames=0):
+        '''
+        Write log message to channel
+
+        Parameters
+        ----------
+        severity: str
+            Severity of the log message to record
+        module: str
+            Module where the error message is occurring
+        error_code_offset: int
+            Error code offset
+        description: str
+            String describing the error message
+        additional_back_frames: int
+            Number of additional frames for inspected object
+        '''
         severity = severity.title()
         self.increment_log_count_by_severity(severity)
 
@@ -109,26 +180,86 @@ class Logger:
 
         self.channel.log(message)
 
-    def info(self, module, error_code_offset, description):
+    def info(self, module, error_code_offset,
+             description):
+        '''
+        Log an info message
+
+        Parameters
+        ----------
+        module: str
+            Module where the error message occur
+        error_code_offset: int
+            Error code offset
+        description: str
+            Description of the message to log
+        '''
         self.write("Info", module, error_code_offset, description,
                    additional_back_frames=1)
 
     def debug(self, module, error_code_offset, description):
+        '''
+        Log an debug message
+
+        Parameters
+        ----------
+        module: str
+            Module where the error message occur
+        error_code_offset: int
+            Error code offset
+        description: str
+            Description of the message to log
+        '''
         self.write("Debug", module, error_code_offset, description,
                    additional_back_frames=1)
 
     def warning(self, module, error_code_offset, description):
+        '''
+        Log an warning message
+
+        Parameters
+        ----------
+        module: str
+            Module where the error message occur
+        error_code_offset: int
+            Error code offset
+        description: str
+            Description of the message to log
+        '''
         self.write("Warning", module, error_code_offset, description,
                    additional_back_frames=1)
 
     def critical(self, module, error_code_offset, description):
+        '''
+        Log an critical message and throw a RuntimeError
+
+        Parameters
+        ----------
+        module: str
+            Module where the error message occur
+        error_code_offset: int
+            Error code offset
+        description: str
+            Description of the message to log
+        '''
         self.write("Critical", module, error_code_offset, description,
                    additional_back_frames=1)
         raise RuntimeError(description)
 
     def log(self, module, error_code_offset, description,
             additional_back_frames=0):
+        '''
+        Log any message
+
+        Parameters
+        ----------
+        module: str
+            Module where the error message occur
+        error_code_offset: int
+            Error code offset
+        description: str
+            Description of the message to log
+        '''
         severity = get_severity_from_error_code(error_code_offset)
         self.write(severity, module, error_code_offset, description,
                    additional_back_frames=additional_back_frames + 1)
-

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -81,7 +81,7 @@ def validate_group_dict(group_cfg: dict) -> None:
     helpers.check_write_dir(os.path.dirname(log_group['path']))
 
     write_mode = log_group['write_mode']
-    journal.debug.journal.device = log_group['path']
+    journal.debug.journal.device = "journal.file"
     journal.debug.journal.device.log = open(log_group['path'], write_mode)
 
 

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -76,6 +76,14 @@ def validate_group_dict(group_cfg: dict) -> None:
     helpers.check_write_dir(product_path_group['scratch_path'])
     helpers.check_write_dir(product_path_group['sas_output_file'])
 
+    # Check if logging dir is writeable
+    log_group = group_cfg['logging']
+    helpers.check_write_dir(os.path.dirname(log_group['path']))
+
+    write_mode = log_group['write_mode']
+    journal.debug.journal.device = log_group['path']
+    journal.debug.journal.device.log = open(log_group['path'], write_mode)
+
 
 def get_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
     '''For each burst find corresponding orbit'

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -13,7 +13,7 @@ from compass.utils import helpers
 from compass.utils.wrap_namespace import wrap_namespace
 from s1reader.s1_burst_slc import Sentinel1BurstSlc
 from s1reader.s1_orbit import get_orbit_file_from_list
-from s1reader.s1_reader import burst_from_zip
+from s1reader.s1_reader import load_bursts
 
 
 def validate_group_dict(group_cfg: dict) -> None:
@@ -77,7 +77,7 @@ def validate_group_dict(group_cfg: dict) -> None:
     helpers.check_write_dir(product_path_group['sas_output_file'])
 
 
-def load_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
+def get_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
     '''For each burst find corresponding orbit'
 
     Parameters
@@ -129,7 +129,7 @@ def load_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
         for pol, i_subswath in zip_list:
 
             # loop over burst objs extracted from SAFE zip
-            for burst in burst_from_zip(safe_file, orbit_path, i_subswath, pol):
+            for burst in load_bursts(safe_file, orbit_path, i_subswath, pol):
 
                 burst_id = burst.burst_id
 
@@ -230,7 +230,7 @@ class RunConfig:
         # Convert runconfig dict to SimpleNamespace
         sns = wrap_namespace(default_cfg['runconfig']['groups'])
 
-        bursts = load_bursts(sns)
+        bursts = get_bursts(sns)
 
         return cls(default_cfg['runconfig']['name'], sns, bursts)
 

--- a/src/compass/utils/schemas/cslc_s1.yaml
+++ b/src/compass/utils/schemas/cslc_s1.yaml
@@ -34,6 +34,9 @@ runconfig:
         # This section includes parameters to tweak the workflow
         processing: include('processing_options', required=False)
 
+        # This section is related to logging
+        logging: include('logging_options', required=False)
+
         # Worker options (e.g. enable/disable GPU processing, select GPU device ID)
         worker: include('worker_options', required=False)
 
@@ -91,3 +94,9 @@ processing_options:
    geo2rdr: include('geo2rdr_options', required=False)
    # Options to run resample
    resample: include('resample_options', required=False)
+
+logging_options:
+   # File path where to store log file
+   path: str(required=False)
+   # Log file write mode. 'a': append to existing. 'w': new/overwrite existing
+   write_mode: enum('a', 'w', required=False)


### PR DESCRIPTION
This PR creates and format each entry of the log file at a Python level as:

`<time-tag>, <log level>, <workflow>, <module>, <error code>, <error location>, <logged message>`

where:

- `<time-tag>` is the time the message was logged, should be in ISO format (YYYY-MM-DDTHH:MMSS.mmmmmmZ)
- `<log level>` is the level of the log message, typically “Debug”, “Info”, “Warning”, or “Critical”
- `<workflow>` is typically the name of the SAS or PGE, so in this case “CSLC” or similar
- `<module>` is the name of the Python module where the logging took place
- `<error code>` is an integer code associated to the logged message. You pretty much have free range to define these, but they should be documented somewhere.
- `<error location>` is the file path of the Python module that did the logging, along with the line number concatenated with a colon (ex `/home/conda/opera/COMPASS/rdr2geo.py:645`)
- `<logged message>` is the actual logged message content

Note that this solution is temporary. With `pyre 1.11.2` and the use of the newly implemented NISAR device inside pyre should automatically format the logging message as above with the exception of assigning an error code. 

**TO DO**:

1. Assign error codes for Warnings, Critical etc for ISCE3 related errors (deserves group discussion)