### PR TITLE
Change geocoded burst Interface

### DIFF
--- a/src/compass/utils/defaults/geo_cslc_s1.yaml
+++ b/src/compass/utils/defaults/geo_cslc_s1.yaml
@@ -10,16 +10,8 @@ runconfig:
           safe_file_path:
           # Required. List of orbit (EOF) files (min=1)
           orbit_file_path:
-          # Required. Path to annotation file
-          annotation_file_path:
-          # Required. Path to RFI file
-          rfi_file_path:
-          # Required. Path to noise file
-          noise_file_path:
-          # Required. Path to calibration file
-          calibration_file_path:
           # Required. Path to the burst data
-          burst_file_path: 
+          burst_file_path:
           # Required. Path to light metadata file
           ligh_metadata_path:
           # Required. The unique burst ID to process

--- a/src/compass/utils/defaults/geo_cslc_s1.yaml
+++ b/src/compass/utils/defaults/geo_cslc_s1.yaml
@@ -10,6 +10,18 @@ runconfig:
           safe_file_path:
           # Required. List of orbit (EOF) files (min=1)
           orbit_file_path:
+          # Required. Path to annotation file
+          annotation_file_path:
+          # Required. Path to RFI file
+          rfi_file_path:
+          # Required. Path to noise file
+          noise_file_path:
+          # Required. Path to calibration file
+          calibration_file_path:
+          # Required. Path to the burst data
+          burst_file_path: 
+          # Required. Path to light metadata file
+          ligh_metadata_path:
           # Required. The unique burst ID to process
           burst_id:
 

--- a/src/compass/utils/schemas/geo_cslc_s1.yaml
+++ b/src/compass/utils/schemas/geo_cslc_s1.yaml
@@ -10,6 +10,18 @@ runconfig:
            safe_file_path: list(str(), min=1)
            # Required. List of orbit (EOF) files
            orbit_file_path: list(str(), min=1)
+           # Required. Path to annotation file
+           annotation_file_path: str(required=True)
+           # Required. Path to RFI file
+           rfi_file_path: str(required=True)
+           # Required. Path to noise file
+           noise_file_path: str(required=True)
+           # Required. Path to calibration file
+           calibration_file_path: str(required=True)
+           # Required. Path to the burst data
+           burst_file_path: str(required=True)
+           # Required. Path to light metadata file
+           ligh_metadata_path: str(required=True)
            # Required. The unique burst ID to process
            burst_id: str(required=True)
 

--- a/src/compass/utils/schemas/geo_cslc_s1.yaml
+++ b/src/compass/utils/schemas/geo_cslc_s1.yaml
@@ -10,14 +10,6 @@ runconfig:
            safe_file_path: list(str(), min=1)
            # Required. List of orbit (EOF) files
            orbit_file_path: list(str(), min=1)
-           # Required. Path to annotation file
-           annotation_file_path: str(required=True)
-           # Required. Path to RFI file
-           rfi_file_path: str(required=True)
-           # Required. Path to noise file
-           noise_file_path: str(required=True)
-           # Required. Path to calibration file
-           calibration_file_path: str(required=True)
            # Required. Path to the burst data
            burst_file_path: str(required=True)
            # Required. Path to light metadata file


### PR DESCRIPTION
This PR includes changes to the interface of the geocoded burst workflow.
The interface now includes paths to:

- annotation file
- calibration file
- rfi file
- noise file
- burst data path
- light metadata path 