### PR TITLE
Typo in geocoded burst schema

### DIFF
--- a/src/compass/utils/defaults/geo_cslc_s1.yaml
+++ b/src/compass/utils/defaults/geo_cslc_s1.yaml
@@ -13,7 +13,7 @@ runconfig:
           # Required. Path to the burst data
           burst_file_path:
           # Required. Path to light metadata file
-          ligh_metadata_path:
+          light_metadata_path:
           # Required. The unique burst ID to process
           burst_id:
 

--- a/src/compass/utils/schemas/geo_cslc_s1.yaml
+++ b/src/compass/utils/schemas/geo_cslc_s1.yaml
@@ -13,7 +13,7 @@ runconfig:
            # Required. Path to the burst data
            burst_file_path: str(required=True)
            # Required. Path to light metadata file
-           ligh_metadata_path: str(required=True)
+           light_metadata_path: str(required=True)
            # Required. The unique burst ID to process
            burst_id: str(required=True)
 


### PR DESCRIPTION
This PR fixes the a mispelled schema entry in the geocoded burst workflow.