### PR TITLE
add `version.py` as the single-source version history

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = compass
-version = 0.1.0
+version = attr: compass.__version__
 description = A Package to Generate Coregistered Multi-temporal SAR SLC
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -28,4 +28,3 @@ where = src
 [options.entry_points]
 console_scripts =
     s1_cslc.py = compass.s1_cslc:main
-

--- a/src/compass/__init__.py
+++ b/src/compass/__init__.py
@@ -1,0 +1,2 @@
+# get version info
+from compass.version import release_version as __version__

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -14,5 +14,3 @@ release_history = (
 release_version = release_history[0].version
 release_date = release_history[0].date
 
-# variable
-__version__ = release_version

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -1,0 +1,18 @@
+# release history
+
+import collections
+
+
+# release history
+Tag = collections.namedtuple('Tag', 'version date')
+release_history = (
+    Tag('0.1.1', '2022-06-08'),
+    Tag('0.1.0', '2022-06-07'),
+)
+
+# latest release version number and date
+release_version = release_history[0].version
+release_date = release_history[0].date
+
+# variable
+__version__ = release_version


### PR DESCRIPTION
This PR adds a `version.py` to store all the release history in one single source file, to access the `compass.__version__` variable and to pass it to the `setup.cfg` file.