### PR TITLE
Dockerfile for S1 CSLC point release

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@
 FROM ubuntu:22.04
 
 LABEL author="OPERA ADT" \
-      description="s1 cslc 0.1.0 IF release" \
-      version="0.1.0_IF"
+      description="s1 cslc 0.1.0 point release" \
+      version="interface_0.1"
 
 RUN apt-get -y update &&\
     apt-get -y install curl git &&\
@@ -28,16 +28,16 @@ RUN $CONDA_PREFIX/bin/conda init bash
 
 RUN conda create --name "COMPASS" --file specifile.txt
 
+SHELL ["conda", "run", "-n", "COMPASS", "/bin/bash", "-c"]
+
 RUN echo "Installing OPERA s1-reader" &&\
     mkdir -p $HOME/OPERA &&\
     cd $HOME/OPERA &&\
-    curl -sSL https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.1.0.tar.gz -o s1_reader_src.tar.gz &&\
+    curl -sSL https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.1.2.tar.gz -o s1_reader_src.tar.gz &&\
     tar -xvf s1_reader_src.tar.gz &&\
-    ln -s s1-reader-0.1.0 s1-reader &&\
+    ln -s s1-reader-0.1.2 s1-reader &&\
     rm s1_reader_src.tar.gz &&\
     python -m pip install ./s1-reader
-
-SHELL ["conda", "run", "-n", "COMPASS", "/bin/bash", "-c"]
 
 COPY . /home/compass_user/OPERA/COMPASS
 
@@ -47,9 +47,13 @@ USER compass_user
 
 RUN echo "Installing OPERA COMPASS" &&\
     cd $HOME/OPERA &&\
-    python -m pip install ./COMPASS
+    python -m pip install ./COMPASS &&\
+    mkdir -p /home/compass_user/scratch &&\
+    chmod -R o+rwx /home/compass_user/scratch &&\
+    echo "conda activate COMPASS" >> /home/compass_user/.bashrc
+
 
 WORKDIR /home/compass_user/scratch
 
-#for COMPASS 0.1.1
+#for COMPASS 0.1.1 and future releases
 ENTRYPOINT ["conda", "run", "-n", "COMPASS","s1_cslc.py"]


### PR DESCRIPTION
This modification on Dockerfile is for point release of S1 CSLC software.
- the version of s1-reader has changed from `0.1.0` to `0.1.2`
- A fix that s1-reader gets installed outside of the desirable conda environment `COMPASS`
- The conda environment `COMPASS` in the container will be automatically activated when the user gets into the container by overriding the entry point to `/bin/bash`
- Addressing the WORKDIR issue suggested by @jshimada47