### PR TITLE
setup: access version w/o __init__ to avoid circular imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = compass
-version = attr: compass.__version__
+version = attr: compass.version.release_version
 description = A Package to Generate Coregistered Multi-temporal SAR SLC
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This is the same as https://github.com/opera-adt/s1-reader/pull/56