### PR TITLE
Modify CSLC validation script

### DIFF
--- a/src/compass/utils/validate_cslc.py
+++ b/src/compass/utils/validate_cslc.py
@@ -135,10 +135,10 @@ def compare_cslc_products(file_ref, file_sec):
     for dtype_op, dtype_str in zip([np.real, np.imag],
                                    ['real', 'imag']):
         # compute difference pixel by pixel
-        diff = (dtype_op(ma_slc_ref) - dtype_op(ma_slc_sec)) / dtype_op(ma_slc_sec)
+        diff = (dtype_op(ma_slc_ref) - dtype_op(ma_slc_sec)) / dtype_op(ma_slc_ref)
 
         # count number of pixels that exceed threshold
-        n_diff_gt_threshold = np.count_non_zero(diff > pixel_diff_threshold)
+        n_diff_gt_threshold = np.count_nonzero(diff > pixel_diff_threshold)
 
         # compute percentage of pixels that fail
         percent_fail = n_diff_gt_threshold / tot_pixels_ref
@@ -148,9 +148,9 @@ def compare_cslc_products(file_ref, file_sec):
             dtype_fails.append(dtype_str)
 
     # check no fails occurred by check of
-    err_str = f'Percentage of pixels in the difference between reference and '
-              f'secondary products parts above the threshold {pixel_diff_threshold} '
-              f'is above {percent_fail_threshold*100}% for: '
+    err_str = f'Percentage of pixels in the difference between reference ' \
+              f'and secondary products parts above the threshold ' \
+              f'{pixel_diff_threshold} is above {percent_fail_threshold*100}% for: '
     assert len(dtype_fails) == 0, err_str + ','.join(dtype_fails)
 
 

--- a/src/compass/utils/validate_cslc.py
+++ b/src/compass/utils/validate_cslc.py
@@ -110,12 +110,32 @@ def compare_cslc_products(file_ref, file_sec):
         return
 
     # Compare amplitude of reference and generated CSLC products
-    print('Check mean real part difference between CSLC products is < 1.0e-5')
-    assert np.allclose(slc_ref.real, slc_sec.real,
-                       atol=0.0, rtol=1.0e-5, equal_nan=True)
-    print('Check mean imaginary part difference between CSLC products is < 1.0e-5')
-    assert np.allclose(slc_ref.imag, slc_sec.imag,
-                       atol=0.0, rtol=1.0e-5, equal_nan=True)
+    diff_real = slc_ref.real - slc_sec.real
+    diff_imag = slc_ref.imag - slc_sec.imag
+
+    # Compute total number of pixels different from nan from ref and sec
+    tot_pixels_ref = np.count_nonzero(~np.isnan(np.abs(slc_ref)))
+    tot_pixels_sec = np.count_nonzero(~np.isnan(np.abs(slc_ref)))
+
+    # Check that total number of pixel is the same
+    assert tot_pixels_ref == tot_pixels_sec
+
+    # Compute the number of pixels in real part above threshold
+    pixels_real = np.count_nonzero(diff_real > 1.0e-5)
+    pixels_imag = np.count_nonzero(diff_imag > 1.0e-5)
+
+    # Compute percentage of pixels in real and imaginary part above threshold
+    percentage_real = pixels_real / tot_pixels_ref
+    percentage_imag = pixels_imag / tot_pixels_ref
+
+    # Check that percentage of pixels above threshold is lower than 0.1 %
+    print('Check that the percentage of pixels in the difference between reference'
+          'and secondary products real parts is below 0.1 %')
+    assert percentage_real < 0.1
+
+    print('Check that the percentage of pixels in the difference between reference'
+          'and secondary products imaginary parts is below 0.1 %')
+    assert percentage_imag < 0.1
 
 
 def _get_group_item_paths(h5py_group):

--- a/src/compass/utils/validate_cslc.py
+++ b/src/compass/utils/validate_cslc.py
@@ -110,8 +110,8 @@ def compare_cslc_products(file_ref, file_sec):
         return
 
     # Compare amplitude of reference and generated CSLC products
-    diff_real = slc_ref.real - slc_sec.real
-    diff_imag = slc_ref.imag - slc_sec.imag
+    diff_real = np.abs((slc_ref.real - slc_sec.real) / slc_sec.real)
+    diff_imag =  np.abs((slc_ref.imag - slc_sec.imag) / slc_sec.imag)
 
     # Compute total number of pixels different from nan from ref and sec
     tot_pixels_ref = np.count_nonzero(~np.isnan(np.abs(slc_ref)))
@@ -121,21 +121,21 @@ def compare_cslc_products(file_ref, file_sec):
     assert tot_pixels_ref == tot_pixels_sec
 
     # Compute the number of pixels in real part above threshold
-    pixels_real = np.count_nonzero(diff_real > 1.0e-5)
-    pixels_imag = np.count_nonzero(diff_imag > 1.0e-5)
+    failed_pixels_real = np.count_nonzero(diff_real > 1.0e-5)
+    failed_pixels_imag = np.count_nonzero(diff_imag > 1.0e-5)
 
     # Compute percentage of pixels in real and imaginary part above threshold
-    percentage_real = pixels_real / tot_pixels_ref
-    percentage_imag = pixels_imag / tot_pixels_ref
+    percentage_real = failed_pixels_real / tot_pixels_ref
+    percentage_imag = failed_pixels_imag / tot_pixels_ref
 
     # Check that percentage of pixels above threshold is lower than 0.1 %
     print('Check that the percentage of pixels in the difference between reference'
           'and secondary products real parts is below 0.1 %')
-    assert percentage_real < 0.1
+    assert percentage_real < 0.001
 
     print('Check that the percentage of pixels in the difference between reference'
           'and secondary products imaginary parts is below 0.1 %')
-    assert percentage_imag < 0.1
+    assert percentage_imag < 0.001
 
 
 def _get_group_item_paths(h5py_group):

--- a/src/compass/utils/validate_cslc.py
+++ b/src/compass/utils/validate_cslc.py
@@ -110,6 +110,7 @@ def compare_cslc_products(file_ref, file_sec):
         return
 
     # Compare amplitude of reference and generated CSLC products
+    np.seterr(invalid='ignore')
     diff_real = np.abs((slc_ref.real - slc_sec.real) / slc_sec.real)
     diff_imag =  np.abs((slc_ref.imag - slc_sec.imag) / slc_sec.imag)
 
@@ -130,11 +131,11 @@ def compare_cslc_products(file_ref, file_sec):
 
     # Check that percentage of pixels above threshold is lower than 0.1 %
     print('Check that the percentage of pixels in the difference between reference'
-          'and secondary products real parts is below 0.1 %')
+          'and secondary products real parts above the threshold 1.0e-5 is below 0.1 %')
     assert percentage_real < 0.001
 
     print('Check that the percentage of pixels in the difference between reference'
-          'and secondary products imaginary parts is below 0.1 %')
+          'and secondary products imaginary parts above the threshold 1.0e-5 is below 0.1 % %')
     assert percentage_imag < 0.001
 
 


### PR DESCRIPTION
The CSLC validation script performs a pixel-wise comparison of the difference between the real and imaginary parts of a reference and secondary products and fails when even one pixel is above a fixed threshold (1.0e-5).

This PR keeps the pixel-wise comparison but makes the validation script fail if the percentage of pixels for which the difference between the real and imaginary parts is above 0.1 %. 

