### PR TITLE
Apply corrections in geocodeSlc module

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -57,6 +57,9 @@ runconfig:
               high_band_bandwidth: 1e7
 
           correction_luts:
+              # Boolean flag to activate/deactivate model-based
+              # corrections while geocoding the burst
+              enabled: True
               # LUT spacing in range direction in meters
               range_spacing: 120
               # LUT spacing in azimuth direction in seconds

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -20,7 +20,7 @@ from compass.utils.h5_helpers import (corrections_to_h5group,
                                       init_geocoded_dataset,
                                       metadata_to_h5group)
 from compass.utils.helpers import get_module_name
-from compass.utils.lut import compute_geocoding_correction_luts
+from compass.utils.lut import cumulative_correction_luts
 from compass.utils.range_split_spectrum import range_split_spectrum
 from compass.utils.yaml_argparse import YamlArgparse
 
@@ -62,23 +62,10 @@ def run(cfg: GeoRunConfig):
 
         # If enabled, get range and azimuth LUTs
         if cfg.lut_params.enabled:
-            geometrical_steer_doppler, bistatic_delay, az_fm_mismatch =\
-                compute_geocoding_correction_luts(burst,
-                                                  dem_path=cfg.dem,
-                                                  rg_step=cfg.lut_params.range_spacing,
-                                                  az_step=cfg.lut_params.azimuth_spacing)
-            rg_lut_data = geometrical_steer_doppler.data
-            az_lut_data = bistatic_delay.data + az_fm_mismatch.data
-            rg_lut = isce3.core.LUT2d(bistatic_delay.x_start,
-                                      bistatic_delay.y_start,
-                                      bistatic_delay.x_spacing,
-                                      bistatic_delay.y_spacing,
-                                      rg_lut_data)
-            az_lut = isce3.core.LUT2d(bistatic_delay.x_start,
-                                      bistatic_delay.y_start,
-                                      bistatic_delay.x_spacing,
-                                      bistatic_delay.y_spacing,
-                                      az_lut_data)
+            rg_lut, az_lut = cumulative_correction_luts(burst,
+                                                        dem_path=cfg.dem,
+                                                        rg_step=cfg.lut_params.range_spacing,
+                                                        az_step=cfg.lut_params.azimuth_spacing)
         else:
             rg_lut = isce3.core.LUT2d()
             az_lut = isce3.core.LUT2d()

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -91,6 +91,9 @@ range_split_spectrum_options:
   high_band_bandwidth: num(min=0, required=False)
 
 lut_options:
+  # Boolean flag to activate/deactivate model-based
+  # corrections while geocoding the burst
+  enabled: bool(required=False)
   # LUT spacing in range direction in meters
   range_spacing: num(min=0, required=False)
   # LUT spacing in azimuth direction in seconds

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -561,43 +561,44 @@ def corrections_to_h5group(parent_group, burst, cfg):
     '''
     correction_group = parent_group.require_group('corrections')
 
-    # Get range and azimuth LUTs
-    geometrical_steering_doppler, bistatic_delay_lut, az_fm_mismatch = \
-        compute_geocoding_correction_luts(burst,
-                                          dem_path=cfg.dem,
-                                          rg_step=cfg.lut_params.range_spacing,
-                                          az_step=cfg.lut_params.azimuth_spacing)
+    # If enabled, save the correction LUTs
+    if cfg.lut_params.enabled:
+        geometrical_steering_doppler, bistatic_delay_lut, az_fm_mismatch = \
+            compute_geocoding_correction_luts(burst,
+                                              dem_path=cfg.dem,
+                                              rg_step=cfg.lut_params.range_spacing,
+                                              az_step=cfg.lut_params.azimuth_spacing)
 
-    # create linspace for axises shared by both LUTs
-    x_end = bistatic_delay_lut.x_start + bistatic_delay_lut.width * bistatic_delay_lut.x_spacing
-    slant_range = np.linspace(bistatic_delay_lut.x_start, x_end,
-                              bistatic_delay_lut.width, dtype=np.float64)
-    y_end = bistatic_delay_lut.y_start + bistatic_delay_lut.length * bistatic_delay_lut.y_spacing
-    azimuth = np.linspace(bistatic_delay_lut.y_start, y_end,
-                          bistatic_delay_lut.length, dtype=np.float64)
+        # create slant range and azimuth vectors shared by the LUTs
+        x_end = bistatic_delay_lut.x_start + bistatic_delay_lut.width * bistatic_delay_lut.x_spacing
+        slant_range = np.linspace(bistatic_delay_lut.x_start, x_end,
+                                  bistatic_delay_lut.width, dtype=np.float64)
+        y_end = bistatic_delay_lut.y_start + bistatic_delay_lut.length * bistatic_delay_lut.y_spacing
+        azimuth = np.linspace(bistatic_delay_lut.y_start, y_end,
+                              bistatic_delay_lut.length, dtype=np.float64)
 
-    # correction LUTs axis and doppler correction LUTs
-    desc = ' correction as a function of slant range and azimuth time'
-    correction_items = [
-        Meta('slant_range', slant_range, 'slant range of LUT data',
-             {'units': 'meters'}),
-        Meta('slant_range_spacing', bistatic_delay_lut.x_spacing,
-             'spacing of slant range of LUT data', {'units': 'meters'}),
-        Meta('zero_doppler_time', azimuth, 'azimuth time of LUT data',
-             {'units': 'seconds'}),
-        Meta('zero_doppler_time_spacing', bistatic_delay_lut.y_spacing,
-             'spacing of azimuth time of LUT data', {'units': 'seconds'}),
-        Meta('bistatic_delay', bistatic_delay_lut.data,
-             f'bistatic delay (azimuth) {desc}', {'units': 'seconds'}),
-        Meta('geometry_steering_doppler', geometrical_steering_doppler.data,
-             f'geometry steering doppler (range) {desc}',
-             {'units': 'meters'}),
-        Meta('azimuth_fm_rate_mismatch', az_fm_mismatch.data,
-             f'azimuth FM rate mismatch mitigation (azimuth) {desc}',
-             {'units': 'seconds'}),
-    ]
-    for meta_item in correction_items:
-        add_dataset_and_attrs(correction_group, meta_item)
+        # correction LUTs axis and doppler correction LUTs
+        desc = ' correction as a function of slant range and azimuth time'
+        correction_items = [
+            Meta('slant_range', slant_range, 'slant range of LUT data',
+                {'units': 'meters'}),
+            Meta('slant_range_spacing', bistatic_delay_lut.x_spacing,
+                 'spacing of slant range of LUT data', {'units': 'meters'}),
+            Meta('zero_doppler_time', azimuth, 'azimuth time of LUT data',
+                 {'units': 'seconds'}),
+            Meta('zero_doppler_time_spacing', bistatic_delay_lut.y_spacing,
+                 'spacing of azimuth time of LUT data', {'units': 'seconds'}),
+            Meta('bistatic_delay', bistatic_delay_lut.data,
+                 f'bistatic delay (azimuth) {desc}', {'units': 'seconds'}),
+            Meta('geometry_steering_doppler', geometrical_steering_doppler.data,
+                 f'geometry steering doppler (range) {desc}',
+                 {'units': 'meters'}),
+            Meta('azimuth_fm_rate_mismatch', az_fm_mismatch.data,
+                 f'azimuth FM rate mismatch mitigation (azimuth) {desc}',
+                 {'units': 'seconds'}),
+        ]
+        for meta_item in correction_items:
+            add_dataset_and_attrs(correction_group, meta_item)
 
     # Extended FM rate and doppler centroid polynomial coefficients for azimuth
     # FM rate mismatch mitigation

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -578,7 +578,7 @@ def corrections_to_h5group(parent_group, burst, cfg):
                               bistatic_delay_lut.length, dtype=np.float64)
 
         # correction LUTs axis and doppler correction LUTs
-        desc = ' correction as a function of slant range and azimuth time'
+        desc = 'correction as a function of slant range and azimuth time'
         correction_items = [
             Meta('slant_range', slant_range, 'slant range of LUT data',
                 {'units': 'meters'}),


### PR DESCRIPTION
This PR allows to enable/disable the computation and the application of the model-based correction LUTs while geocoding a S1-A/B burst.
If the application of the correction LUTs is requested, the correction layers along with their spacings and slant range and azimuth vectors are saved within the CSLC-S1 product. If not requested, the `corrections` group within the product is left empty.

