### PR TITLE
Include default values in runconfig written to HDF5 metadata

### DIFF
--- a/src/compass/utils/geo_runconfig.py
+++ b/src/compass/utils/geo_runconfig.py
@@ -84,7 +84,7 @@ class GeoRunConfig(RunConfig):
 
         # For saving entire file with default fill-in as string to metadata.
         # Stop gap for writing dict to individual elements to HDF5 metadata
-        user_plus_default_yaml_str = yaml.dump(cfg_dict)
+        user_plus_default_yaml_str = yaml.dump(cfg)
 
         # Get scratch and output paths
         output_paths = create_output_paths(sns, bursts)
@@ -122,7 +122,7 @@ class GeoRunConfig(RunConfig):
         return self_as_dict
 
 
-    def to_file(self, dst, fmt:str, add_burst_boundary=True):
+    def to_file(self, dst, fmt:str):
         ''' Write self to file
 
         Parameter:
@@ -131,9 +131,6 @@ class GeoRunConfig(RunConfig):
             File object to write metadata to
         fmt: ['yaml', 'json']
             Format of output
-        add_burst_boundary: bool
-            If true add burst boundary string to each burst entry in dict.
-            Reads geocoded burst rasters; only viable after running s1_geocode_slc.
         '''
         self_as_dict = self.as_dict()
 
@@ -142,8 +139,8 @@ class GeoRunConfig(RunConfig):
         self_as_dict['isce3_version'] = isce3.__version__
 
         if fmt == 'yaml':
-            yaml = YAML(typ='safe')
-            yaml.dump(self_as_dict, dst)
+            yaml_obj = YAML(typ='safe')
+            yaml_obj.dump(self_as_dict, dst)
         elif fmt == 'json':
             json.dumps(self_as_dict, dst, indent=4)
         else:

--- a/src/compass/utils/geo_runconfig.py
+++ b/src/compass/utils/geo_runconfig.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 import json
+import yaml
 
 import isce3
 from isce3.product import GeoGridParameters
@@ -81,14 +82,15 @@ class GeoRunConfig(RunConfig):
         # Empty reference dict for base runconfig class constructor
         empty_ref_dict = {}
 
-        with open(yaml_path, 'r') as f_yaml:
-            entire_yaml = f_yaml.read()
+        # For saving entire file with default fill-in as string to metadata.
+        # Stop gap for writing dict to individual elements to HDF5 metadata
+        user_plus_default_yaml_str = yaml.dump(cfg_dict)
 
         # Get scratch and output paths
         output_paths = create_output_paths(sns, bursts)
 
         return cls(cfg['runconfig']['name'], sns, bursts, empty_ref_dict,
-                   entire_yaml, output_paths, geogrids)
+                   user_plus_default_yaml_str, output_paths, geogrids)
 
     @property
     def geocoding_params(self) -> dict:

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import os
 from types import SimpleNamespace
 import sys
+import yaml
 
 import isce3
 import journal
@@ -26,6 +27,11 @@ def load_validate_yaml(yaml_path: str, workflow_name: str) -> dict:
         Path to yaml file containing the options to load
     workflow_name: str
         Name of the workflow for which uploading default options
+
+    Returns
+    -------
+    dict
+        Validated user runconfig dict with defaults inserted
     """
     error_channel = journal.error('runconfig.load_validate_yaml')
 
@@ -346,15 +352,14 @@ class RunConfig:
                 sns.input_file_group.reference_burst.file_path,
                 sns.input_file_group.burst_id)
 
-        # For saving entire file as string to metadata. Stop gap for writing
-        # dict to individual elements to HDF5 metadata
-        with open(yaml_path, 'r') as f_yaml:
-            entire_yaml = f_yaml.read()
+        # For saving entire file with default fill-in as string to metadata.
+        # Stop gap for writing dict to individual elements to HDF5 metadata
+        user_plus_default_yaml_str = yaml.dump(cfg_dict)
 
         output_paths = create_output_paths(sns, bursts)
 
         return cls(cfg['runconfig']['name'], sns, bursts, ref_rdr_grid_info,
-                   entire_yaml, output_paths)
+                   user_plus_default_yaml_str, output_paths)
 
     @property
     def burst_id(self) -> list[str]:

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -352,7 +352,7 @@ class RunConfig:
                 sns.input_file_group.reference_burst.file_path,
                 sns.input_file_group.burst_id)
 
-        # For saving entire file with default fill-in as string to metadata.
+        # For saving entire file with defaults filled-in as string to metadata.
         # Stop gap for writing dict to individual elements to HDF5 metadata
         user_plus_default_yaml_str = yaml.dump(cfg)
 

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -354,7 +354,7 @@ class RunConfig:
 
         # For saving entire file with default fill-in as string to metadata.
         # Stop gap for writing dict to individual elements to HDF5 metadata
-        user_plus_default_yaml_str = yaml.dump(cfg_dict)
+        user_plus_default_yaml_str = yaml.dump(cfg)
 
         output_paths = create_output_paths(sns, bursts)
 
@@ -458,5 +458,5 @@ class RunConfig:
         '''Dump runconfig as string to sys.stdout
         '''
         self_as_dict = self.as_dict()
-        yaml = YAML(typ='safe')
-        yaml.dump(self_as_dict, sys.stdout)
+        yaml_obj = YAML(typ='safe')
+        yaml_obj.dump(self_as_dict, sys.stdout)


### PR DESCRIPTION
This PR adds default values to runconfig string written to the HDF5 metadata. Currently only the user input runconfig is written to HDF5 metadata.