### PR TITLE
use `Path().parent` instead of dirname in runconfig.py

### DIFF
--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 import os
+from pathlib import Path
 from types import SimpleNamespace
 import sys
 import yaml
@@ -169,7 +170,7 @@ def runconfig_to_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
         # get orbit file from directory of first orbit file
         orbit_path = get_orbit_file_from_dir(
             safe_file,
-            os.path.dirname(cfg.input_file_group.orbit_file_path[0]))
+            Path(cfg.input_file_group.orbit_file_path[0]).parent)
 
         if not orbit_path:
             err_str = f"No orbit file correlates to safe file: {os.path.basename(safe_file)}"


### PR DESCRIPTION
Changing the only place where `dirname` is used directly on a string passed by the user, rather than something we construct.

`os.path.dirname` fails in the s1reader's orbit-getter if you pass just the name of a file in the current directory without `./` in front.

```python
from pathlib import Path
import os

orbit_file = 'S1A_OPER_AUX_POEORB_OPOD_20220802T081843_V20220712T225942_20220714T005942.EOF'
os.path.exists(orbit_file)
# True
os.path.isdir(os.path.dirname(orbit_file))
# False
```
which leads to an error 
```
Traceback (most recent call last):
  File "/u/aurora-r0/staniewi/miniconda3/envs/mapping/lib/python3.10/site-packages/ipdb/__main__.py", line 305, in main
    pdb._runscript(mainpyfile)
  File "/u/aurora-r0/staniewi/miniconda3/envs/mapping/lib/python3.10/pdb.py", line 1586, in _runscript
    self.run(statement)
  File "/u/aurora-r0/staniewi/miniconda3/envs/mapping/lib/python3.10/bdb.py", line 597, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/u/aurora-r0/staniewi/miniconda3/envs/mapping/bin/s1_cslc.py", line 8, in <module>
    sys.exit(main())
  File "/u/aurora-r0/staniewi/repos/COMPASS/src/compass/s1_cslc.py", line 49, in main
    run(parser.run_config_path, parser.args.grid_type)
  File "/u/aurora-r0/staniewi/repos/COMPASS/src/compass/s1_cslc.py", line 40, in run
    cfg = GeoRunConfig.load_from_yaml(run_config_path, 's1_cslc_geo')
  File "/u/aurora-r0/staniewi/repos/COMPASS/src/compass/utils/geo_runconfig.py", line 70, in load_from_yaml
    bursts = runconfig_to_bursts(sns)
  File "/u/aurora-r0/staniewi/repos/COMPASS/src/compass/utils/runconfig.py", line 164, in runconfig_to_bursts
    orbit_path = get_orbit_file_from_dir(
  File "/u/aurora-r0/staniewi/repos/s1-reader/src/s1reader/s1_orbit.py", line 249, in get_orbit_file_from_dir
    raise NotADirectoryError(f"{orbit_dir} not found")
NotADirectoryError:  not found
```

But if you use `pathlib`, it works fine.
```python
os.path.isdir(Path(orbit_file).parent)
True

```