### PR TITLE
s1_geocode_stack.py: set `auto_download=True` when getting orbits

### DIFF
--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -114,7 +114,7 @@ def generate_burst_map(zip_files, orbit_dir, output_epsg=None, bbox=None,
     i_subswath = [1, 2, 3]
 
     for zip_file in zip_files:
-        orbit_path = get_orbit_file_from_dir(zip_file, orbit_dir)
+        orbit_path = get_orbit_file_from_dir(zip_file, orbit_dir, auto_download=True)
 
         for subswath in i_subswath:
             ref_bursts = load_bursts(zip_file, orbit_path, subswath)


### PR DESCRIPTION
While talking about some COMPASS testing that @gracebato was doing, we both realized that after installing COMPASS, the first thing we would do is change the geocode stack script to have `auto_download=True` since you always want to get the orbits for a new area.

(This was also related to https://github.com/opera-adt/s1-reader/pull/100, but I thought that fix made more sense to go into s1reader)
