### PR TITLE
Avoid compute corrections twice

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -71,12 +71,20 @@ def run(cfg: GeoRunConfig):
         date_str = burst.sensing_start.strftime("%Y%m%d")
         geo_grid = cfg.geogrids[burst_id]
 
+        # Get output paths for current burst
+        burst_id_date_key = (burst_id, date_str)
+        out_paths = cfg.output_paths[burst_id_date_key]
+
+        # Create scratch as needed
+        scratch_path = out_paths.scratch_directory
+
         # If enabled, get range and azimuth LUTs
         if cfg.lut_params.enabled:
             rg_lut, az_lut = cumulative_correction_luts(burst,
                                                         dem_path=cfg.dem,
                                                         rg_step=cfg.lut_params.range_spacing,
-                                                        az_step=cfg.lut_params.azimuth_spacing)
+                                                        az_step=cfg.lut_params.azimuth_spacing,
+                                                        scratch_path=scratch_path)
         else:
             rg_lut = isce3.core.LUT2d()
             az_lut = isce3.core.LUT2d()
@@ -93,13 +101,6 @@ def run(cfg: GeoRunConfig):
             s1_rdr2geo.run(cfg, save_in_scratch=True)
             if cfg.rdr2geo_params.geocode_metadata_layers:
                 s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
-
-        # Get output paths for current burst
-        burst_id_date_key = (burst_id, date_str)
-        out_paths = cfg.output_paths[burst_id_date_key]
-
-        # Create scratch as needed
-        scratch_path = out_paths.scratch_directory
 
         # Extract burst boundaries
         b_bounds = np.s_[burst.first_valid_line:burst.last_valid_line,

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -194,7 +194,7 @@ def run(cfg: GeoRunConfig):
 
             cslc_group = geo_burst_h5.require_group(f'{root_path}/CSLC')
             metadata_to_h5group(cslc_group, burst, cfg)
-            corrections_to_h5group(cslc_group, burst, cfg)
+            corrections_to_h5group(cslc_group, burst, cfg, rg_lut, az_lut, scratch_path)
 
     dt = str(timedelta(seconds=time.time() - t_start)).split(".")[0]
     info_channel.log(f"{module_name} burst successfully ran in {dt} (hr:min:sec)")

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -7,7 +7,7 @@ import os
 
 import isce3
 import numpy as np
-from osgeo import osr
+from osgeo import osr, gdal
 import s1reader
 from s1reader.s1_burst_slc import Sentinel1BurstSlc
 import shapely
@@ -549,7 +549,8 @@ def metadata_to_h5group(parent_group, burst, cfg):
     poly1d_to_h5(burst_meta_group, 'doppler', burst.doppler.poly1d)
 
 
-def corrections_to_h5group(parent_group, burst, cfg):
+def corrections_to_h5group(parent_group, burst, cfg, rg_lut, az_lut,
+                           scratch_path):
     '''
     Write azimuth, slant range, and EAP (if needed) correction LUT2ds to HDF5
 
@@ -561,42 +562,47 @@ def corrections_to_h5group(parent_group, burst, cfg):
         Burst containing corrections
     cfg: types.SimpleNamespace
         SimpleNamespace containing run configuration
+    rg_lut: isce3.core.LUT2d()
+        LUT2d along slant direction
+    az_lut: isce3.core.LUT2d()
+        LUT2d along azimuth direction
+    scratch_path: str
+        Path to the scratch directory
     '''
+
+    # Open GDAL dataset to fetch corrections
+    ds = gdal.Open(f'{scratch_path}/corrections/corrections',
+                   gdal.GA_ReadOnly)
     correction_group = parent_group.require_group('corrections')
 
     # If enabled, save the correction LUTs
     if cfg.lut_params.enabled:
-        geometrical_steering_doppler, bistatic_delay_lut, az_fm_mismatch = \
-            compute_geocoding_correction_luts(burst,
-                                              dem_path=cfg.dem,
-                                              rg_step=cfg.lut_params.range_spacing,
-                                              az_step=cfg.lut_params.azimuth_spacing)
 
         # create slant range and azimuth vectors shared by the LUTs
-        x_end = bistatic_delay_lut.x_start + bistatic_delay_lut.width * bistatic_delay_lut.x_spacing
-        slant_range = np.linspace(bistatic_delay_lut.x_start, x_end,
-                                  bistatic_delay_lut.width, dtype=np.float64)
-        y_end = bistatic_delay_lut.y_start + bistatic_delay_lut.length * bistatic_delay_lut.y_spacing
-        azimuth = np.linspace(bistatic_delay_lut.y_start, y_end,
-                              bistatic_delay_lut.length, dtype=np.float64)
+        x_end = rg_lut.x_start + rg_lut.width * rg_lut.x_spacing
+        slant_range = np.linspace(rg_lut.x_start, x_end,
+                                  rg_lut.width, dtype=np.float64)
+        y_end = az_lut.y_start + az_lut.length * az_lut.y_spacing
+        azimuth = np.linspace(az_lut.y_start, y_end,
+                              az_lut.length, dtype=np.float64)
 
         # correction LUTs axis and doppler correction LUTs
         desc = 'correction as a function of slant range and azimuth time'
         correction_items = [
             Meta('slant_range', slant_range, 'slant range of LUT data',
                 {'units': 'meters'}),
-            Meta('slant_range_spacing', bistatic_delay_lut.x_spacing,
+            Meta('slant_range_spacing', rg_lut.x_spacing,
                  'spacing of slant range of LUT data', {'units': 'meters'}),
             Meta('zero_doppler_time', azimuth, 'azimuth time of LUT data',
                  {'units': 'seconds'}),
-            Meta('zero_doppler_time_spacing', bistatic_delay_lut.y_spacing,
+            Meta('zero_doppler_time_spacing',rg_lut.y_spacing,
                  'spacing of azimuth time of LUT data', {'units': 'seconds'}),
-            Meta('bistatic_delay', bistatic_delay_lut.data,
+            Meta('bistatic_delay', ds.GetRasterBand(2).ReadAsArray(),
                  f'bistatic delay (azimuth) {desc}', {'units': 'seconds'}),
-            Meta('geometry_steering_doppler', geometrical_steering_doppler.data,
+            Meta('geometry_steering_doppler', ds.GetRasterBand(1).ReadAsArray(),
                  f'geometry steering doppler (range) {desc}',
                  {'units': 'meters'}),
-            Meta('azimuth_fm_rate_mismatch', az_fm_mismatch.data,
+            Meta('azimuth_fm_rate_mismatch', ds.GetRasterBand(3).ReadAsArray(),
                  f'azimuth FM rate mismatch mitigation (azimuth) {desc}',
                  {'units': 'seconds'}),
         ]

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -330,12 +330,12 @@ def write_raster(filename, data_list, descriptions,
     Parameters
     ----------
     filename: str
-        Filepath where to store output dataset
-    data_list: list, np.ndarray
+        File path where to store output dataset
+    data_list: list[np.ndarray]
         List of numpy.ndarray to allocate for each
         raster band. All datasets within the list
         are assumed to have the same shape
-    descriptions: list, str
+    descriptions: list[str]
         List of strings containing a description
         for the bands to allocate
     data_type: gdal.dtype
@@ -371,6 +371,3 @@ def write_raster(filename, data_list, descriptions,
 
     out_ds.FlushCache()
     out_ds = None
-
-
-

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -318,3 +318,59 @@ def burst_bboxes_from_db(burst_ids, burst_db_file=None, burst_db_conn=None):
 
     # TODO add warning if not all burst bounding boxes found
     return dict(zip(burst_ids, zip(epsgs, bboxes)))
+
+
+def write_raster(filename, data_list, descriptions,
+                 data_type=gdal.GDT_Float32, format='ENVI'):
+    '''
+    Write a multiband GDAL-friendly raster to disk.
+    Each dataset allocated in the output file contains
+    a description of the dataset allocated for that band
+
+    Parameters
+    ----------
+    filename: str
+        Filepath where to store output dataset
+    data_list: list, np.ndarray
+        List of numpy.ndarray to allocate for each
+        raster band. All datasets within the list
+        are assumed to have the same shape
+    descriptions: list, str
+        List of strings containing a description
+        for the bands to allocate
+    data_type: gdal.dtype
+        GDAL dataset type
+    format: gdal.Format
+        Format for GDAL output file
+    '''
+
+    error_channel = journal.error('helpers.write_raster')
+
+    # Check number of datasets match number of descriptions
+    if len(data_list) != len(descriptions):
+        err_str = f'Number of datasets to write does not match' \
+                  f'the number of descriptions ' \
+                  f'{len(data_list)} != {len(descriptions)}'
+        error_channel.log(err_str)
+        raise ValueError(err_str)
+
+    # Get the shape of a dataset within the list. All the datasets
+    # are assumed to have the same shape
+    length, width = data_list[0].shape
+    nbands = len(data_list)
+
+    driver = gdal.GetDriverByName(format)
+    out_ds = driver.Create(filename, width, length, nbands, data_type)
+
+    band = 0
+    for data, description in zip(data_list, descriptions):
+        band += 1
+        raster_band = out_ds.GetRasterBand(band)
+        raster_band.SetDescription(description)
+        raster_band.WriteArray(data)
+
+    out_ds.FlushCache()
+    out_ds = None
+
+
+

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -321,7 +321,7 @@ def burst_bboxes_from_db(burst_ids, burst_db_file=None, burst_db_conn=None):
 
 
 def write_raster(filename, data_list, descriptions,
-                 data_type=gdal.GDT_Float32, format='ENVI'):
+                 data_type=gdal.GDT_Float32, data_format='ENVI'):
     '''
     Write a multiband GDAL-friendly raster to disk.
     Each dataset allocated in the output file contains
@@ -359,7 +359,7 @@ def write_raster(filename, data_list, descriptions,
     length, width = data_list[0].shape
     nbands = len(data_list)
 
-    driver = gdal.GetDriverByName(format)
+    driver = gdal.GetDriverByName(data_format)
     out_ds = driver.Create(filename, width, length, nbands, data_type)
 
     band = 0
@@ -370,4 +370,3 @@ def write_raster(filename, data_list, descriptions,
         raster_band.WriteArray(data)
 
     out_ds.FlushCache()
-    out_ds = None


### PR DESCRIPTION
This PR proposes an attempt to solve #92 and avoids to compute the correction layers twice.

At the moment, the correction layers are computed 1) to feed them to the geocodeSlc correction module 2) to allocate them inside the CSLC-S1 data product.

In this PR, the corrections are computed once, saved on disk and read when it is time to allocate them in the dataset.
May be there is a smarter way to do this but this PR gives a first stab to the issue.
