### PR TITLE
geocode stack adjustments for a gzipped-json burst db

### DIFF
--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -77,8 +77,7 @@ def create_parser():
 
 
 def generate_burst_map(zip_files, orbit_dir, output_epsg=None, bbox=None,
-                       bbox_epsg=4326, burst_db_file=DEFAULT_BURST_DB_FILE,
-                       min_bbox_intersect=0.01):
+                       bbox_epsg=4326, burst_db_file=DEFAULT_BURST_DB_FILE):
     """Generates a dataframe of geogrid infos for each burst ID in `zip_files`.
 
     Parameters
@@ -117,7 +116,7 @@ def generate_burst_map(zip_files, orbit_dir, output_epsg=None, bbox=None,
             ref_bursts = load_bursts(zip_file, orbit_path, subswath)
             for burst in ref_bursts:
                 epsg, bbox_utm = _get_burst_epsg_and_bbox(
-                    burst, output_epsg, bbox, bbox_epsg, burst_db_file, min_intersect=min_bbox_intersect
+                    burst, output_epsg, bbox, bbox_epsg, burst_db_file,
                 )
                 if epsg is None:  # Flag for skipping burst
                     continue
@@ -135,8 +134,7 @@ def generate_burst_map(zip_files, orbit_dir, output_epsg=None, bbox=None,
     return burst_map
 
 
-def _get_burst_epsg_and_bbox(burst, output_epsg, bbox, bbox_epsg, burst_db_file,
-                             min_intersect=0.01):
+def _get_burst_epsg_and_bbox(burst, output_epsg, bbox, bbox_epsg, burst_db_file):
     """Returns the EPSG code and bounding box for a burst.
 
     Uses specified `bbox` if provided; otherwise, uses burst database (if available).

--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -421,7 +421,7 @@ def run(slc_dir, dem_file, burst_id=None, common_bursts_only=False, start_date=N
 
     # Generate burst map and prune it if a list of burst ID is provided
     search_ext = 'zip' if using_zipped else 'SAFE'
-    zip_file_list = sorted(glob.glob(f'{slc_dir}/S1[AB]_*/*.{search_ext}'))
+    zip_file_list = sorted(glob.glob(f'{slc_dir}/S1[AB]_*.{search_ext}'))
     # Remove zip files that are not in the date range before generating burst map
     zip_file_list = _filter_by_date(zip_file_list, start_date, end_date, exclude_dates)
 

--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -161,12 +161,7 @@ def _get_burst_epsg_and_bbox(burst, output_epsg, bbox, bbox_epsg, burst_db_file,
         burst_border_utm = helpers.polygon_to_utm(
             burst.border[0], epsg_src=4326, epsg_dst=epsg
         )
-        bbox_utm_geom = geometry.box(*bbox_utm)
-        burst_intersection = burst_border_utm.intersection(bbox_utm_geom)
-        # Skip this burst if it doesn't overlap enough with specified bbox
-        total_area = min(bbox_utm_geom.area, burst_border_utm.area)
-        intersect_pct = burst_intersection.area / total_area
-        if intersect_pct < min_intersect:
+        if not geometry.box(*bbox_utm).intersects(burst_border_utm):
             return None, None
     else:
         epsg_db, bbox_utm = helpers.burst_bbox_from_db(

--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -48,8 +48,8 @@ def create_parser():
     optional.add_argument('-exd', '--exclude-dates', nargs='+',
                           help='Date to be excluded from stack processing (format: YYYYMMDD)')
     optional.add_argument('-p', '--pol', dest='pol', nargs='+', default='co-pol',
-                          help='Polarization to process: dual-pol, co-pol, cross-pol '
-                               ' (default: co-pol).')
+                          choices=['co-pol', 'cross-pol', 'dual-pol'],
+                          help='Polarization to process: %(choices)s ')
     optional.add_argument('-dx', '--x-spac', type=float, default=5,
                           help='Spacing in meters of geocoded CSLC along X-direction.')
     optional.add_argument('-dy', '--y-spac', type=float, default=10,
@@ -338,7 +338,7 @@ def _filter_by_date(zip_file_list, start_date, end_date, exclude_dates):
     return zip_file_list
 
 
-def run(slc_dir, dem_file, burst_id, common_bursts_only=False, start_date=None,
+def run(slc_dir, dem_file, burst_id=None, common_bursts_only=False, start_date=None,
         end_date=None, exclude_dates=None, orbit_dir=None, work_dir='stack',
         pol='dual-pol', x_spac=5, y_spac=10, bbox=None, bbox_epsg=4326,
         output_epsg=None, burst_db_file=DEFAULT_BURST_DB_FILE, flatten=True,

--- a/src/compass/utils/geo_grid.py
+++ b/src/compass/utils/geo_grid.py
@@ -313,9 +313,6 @@ def generate_geogrids_from_db(bursts, geo_dict, dem, burst_db_file):
     geo_grids = {}
 
     # get all burst IDs and their EPSGs + bounding boxes
-    burst_ids = [str(b.burst_id) for b in bursts]
-    epsg_bbox_dict = helpers.burst_bboxes_from_db(burst_ids, burst_db_file)
-
     for burst in bursts:
         burst_id = str(burst.burst_id)
 
@@ -325,7 +322,8 @@ def generate_geogrids_from_db(bursts, geo_dict, dem, burst_db_file):
 
         # extract EPSG and bbox for current burst from dict
         # bottom right = (xmax, ymin) and top left = (xmin, ymax)
-        epsg, (xmin, ymin, xmax, ymax) = epsg_bbox_dict[burst_id]
+        epsg, (xmin, ymin, xmax, ymax) = helpers.burst_bbox_from_db(burst_id,
+                                                                    burst_db_file)
 
         radar_grid = burst.as_isce3_radargrid()
         orbit = burst.orbit


### PR DESCRIPTION
This PR has a few changes that came up while testing out the COMPASS wrapper workflow https://github.com/opera-adt/sweets

The main changes are to allow a format of the burst db that's a simple JSON file instead of a sqlite database. Since it takes <1sec to load 1M rows into memory, there's little noticeable difference in the s1_geocode_stack runtime. The nice part is the DB is only ~15 MB when it's a gzipped JSON file.

Something that should be sorted out before this is merged is the burst_db repo, where this was implemented https://github.com/opera-adt/burst_db/compare/main...scottstanie:burst_db:test-json-gz
But really we can store the v1 version of the DB somewhere easy to download because it's so small.

- Also allows us to point to either a list of pre-unzipped .SAFE directories, as well as .zip files.