### PR TITLE
Apply static troposphere model when weather model file is not provided

### DIFF
--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -614,16 +614,19 @@ def corrections_to_h5group(parent_group, burst, cfg, rg_lut, az_lut,
         Meta('los_solid_earth_tides', ds.GetRasterBand(4).ReadAsArray(),
              f'Solid Earth tides (range) {desc}',
              {'units': 'meters'}),
+        Meta('los_ionospheric_delay', ds.GetRasterBand(5).ReadAsArray(),
+             f'Ionospheric delay (range) {desc}',
+             {'units': 'meters'}),
     ]
     if weather_model_path is not None:
         if 'wet' in delay_type:
             correction_items.append(Meta('wet_los_troposphere_delay',
-                                         ds.GetRasterBand(5).ReadAsArray(),
+                                         ds.GetRasterBand(6).ReadAsArray(),
                                          f'Wet LOS troposphere delay {desc}',
                                          {'units': 'meters'}))
         if 'dry' in delay_type:
             correction_items.append(Meta('dry_los_troposphere_delay',
-                                         ds.GetRasterBand(6).ReadAsArray(),
+                                         ds.GetRasterBand(7).ReadAsArray(),
                                          f'Dry LOS troposphere delay {desc}',
                                          {'units': 'meters'}))
 

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -617,7 +617,13 @@ def corrections_to_h5group(parent_group, burst, cfg, rg_lut, az_lut,
                  f'Ionospheric delay (range) {desc}',
                  {'units': 'meters'}),
         ]
-        if weather_model_path is not None:
+
+        if weather_model_path is None:
+            correction_items.append(Meta('static_los_troposphere_delay',
+                                             ds.GetRasterBand(5).ReadAsArray(),
+                                             f'Static LOS troposphere delay {desc}',
+                                             {'units': 'meters'}))
+        else:
             if 'wet' in delay_type:
                 correction_items.append(Meta('wet_los_troposphere_delay',
                                              ds.GetRasterBand(5).ReadAsArray(),

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -618,12 +618,7 @@ def corrections_to_h5group(parent_group, burst, cfg, rg_lut, az_lut,
                  {'units': 'meters'}),
         ]
 
-        if weather_model_path is None:
-            correction_items.append(Meta('static_los_troposphere_delay',
-                                             ds.GetRasterBand(5).ReadAsArray(),
-                                             f'Static LOS troposphere delay {desc}',
-                                             {'units': 'meters'}))
-        else:
+        if weather_model_path is not None:
             if 'wet' in delay_type:
                 correction_items.append(Meta('wet_los_troposphere_delay',
                                              ds.GetRasterBand(5).ReadAsArray(),

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -469,7 +469,7 @@ def compute_static_troposphere_delay(incidence_angle_arr, hgt_arr):
     '''
     ZPD = 2.3
     H = 6000.0
-    
+
     tropo = ZPD / np.cos(np.deg2rad(incidence_angle_arr)) * np.exp(-1 * hgt_arr / H)
 
     return tropo

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -455,9 +455,9 @@ def compute_static_troposphere_delay(incidence_angle_arr, hgt_arr):
     Parameters:
     -----------
     inc_path: str
-        Path to incidence angle raster in radar grid
+        Path to incidence angle raster in radar grid in degrees
     hgt_path: str
-        Path to surface heightraster in radar grid
+        Path to surface heightraster in radar grid in meters
 
     Return:
     -------

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -105,10 +105,7 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
     descr = ['slant range geometrical doppler', 'azimuth bistatic delay', 'azimuth FM rate mismatch',
              'slant range Solid Earth tides', 'line-of-sight ionospheric delay']
 
-    if weather_model_path is None:
-        data_list.append(los_static_tropo)
-        descr.append('static LOS troposphere')
-    else:
+    if weather_model_path is not None:
         if 'wet' in delay_type:
             data_list.append(wet_los_tropo)
             descr.append('wet LOS troposphere')

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -61,7 +61,7 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
     '''
     # Get individual LUTs
     geometrical_steer_doppler, bistatic_delay, az_fm_mismatch, [tide_rg, _], \
-        los_ionosphere, [wet_los_tropo, dry_los_tropo] = \
+        los_ionosphere, [wet_los_tropo, dry_los_tropo], los_static_tropo = \
         compute_geocoding_correction_luts(burst,
                                           dem_path=dem_path,
                                           tec_path=tec_path,
@@ -72,7 +72,7 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
 
     # Convert to geometrical doppler from range time (seconds) to range (m)
     geometry_doppler = geometrical_steer_doppler.data * isce3.core.speed_of_light * 0.5
-    rg_lut_data = geometry_doppler + tide_rg + los_ionosphere
+    rg_lut_data = geometry_doppler + tide_rg + los_ionosphere + los_static_tropo
 
     # Add troposphere delay to range LUT
     if 'wet' in delay_type:
@@ -105,12 +105,16 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
     descr = ['slant range geometrical doppler', 'azimuth bistatic delay', 'azimuth FM rate mismatch',
              'slant range Solid Earth tides', 'line-of-sight ionospheric delay']
 
-    if 'wet' in delay_type:
-        data_list.append(wet_los_tropo)
-        descr.append('wet LOS troposphere')
-    if 'dry' in delay_type:
-        data_list.append(dry_los_tropo)
-        descr.append('dry LOS troposphere')
+    if weather_model_path is None:
+        data_list.append(los_static_tropo)
+        descr.append('static LOS troposphere')
+    else:
+        if 'wet' in delay_type:
+            data_list.append(wet_los_tropo)
+            descr.append('wet LOS troposphere')
+        if 'dry' in delay_type:
+            data_list.append(dry_los_tropo)
+            descr.append('dry LOS troposphere')
 
     write_raster(f'{output_path}/corrections', data_list, descr)
 
@@ -239,9 +243,14 @@ def compute_geocoding_correction_luts(burst, dem_path, tec_path,
                                       tec_path, lon, lat, inc_angle)
 
     # Compute wet and dry troposphere delays using RAiDER
-    wet_los_tropo, dry_los_tropo = [np.zeros(out_shape) for _ in range(2)]
+    wet_los_tropo, dry_los_tropo, los_static_tropo =\
+        [np.zeros(out_shape) for _ in range(3)]
 
-    if weather_model_path is not None:
+    if weather_model_path is None:
+        # Compute static troposphere correction
+        los_static_tropo = compute_static_troposphere_delay(inc_angle, height)
+
+    else:
         # Instantiate an "aoi" object to read lat/lon/height files
         aoi = RasterRDR(rdr2geo_raster_paths[1], rdr2geo_raster_paths[0],
                         rdr2geo_raster_paths[2])
@@ -261,7 +270,7 @@ def compute_geocoding_correction_luts(burst, dem_path, tec_path,
         dry_los_tropo = 2.0 * zen_dry / np.cos(np.deg2rad(inc_angle))
 
     return geometrical_steering_doppler, bistatic_delay, az_fm_mismatch, [
-        rg_set, az_set], los_ionosphere, [wet_los_tropo, dry_los_tropo]
+        rg_set, az_set], los_ionosphere, [wet_los_tropo, dry_los_tropo], los_static_tropo
 
 
 
@@ -440,3 +449,27 @@ def resample_set(geo_tide, pts_src, pts_dest):
                    bounds_error=False, fill_value=0)
     rdr_tide = rgi_func(pts_dest)
     return rdr_tide
+
+
+def compute_static_troposphere_delay(incidence_angle_arr, hgt_arr):
+    '''
+    Compute troposphere delay using static model
+
+    Parameters:
+    -----------
+    inc_path: str
+        Path to incidence angle raster in radar grid
+    hgt_path: str
+    Path to surface heightraster in radar grid
+
+    Return:
+    -------
+    tropo: np.ndarray
+        Troposphere delay in slant range
+    '''
+    ZPD = 2.3
+    H = 6000.0
+    
+    tropo = ZPD / np.cos(np.deg2rad(incidence_angle_arr)) * np.exp(-1 * hgt_arr / H)
+
+    return tropo

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -460,7 +460,7 @@ def compute_static_troposphere_delay(incidence_angle_arr, hgt_arr):
     inc_path: str
         Path to incidence angle raster in radar grid
     hgt_path: str
-    Path to surface heightraster in radar grid
+        Path to surface heightraster in radar grid
 
     Return:
     -------

--- a/tests/test_s1_geocode_slc.py
+++ b/tests/test_s1_geocode_slc.py
@@ -117,4 +117,4 @@ def test_geocode_slc_validate(geocode_slc_params):
 
     # check for bright spots in sliced array
     corner_reflector_threshold = 3e3
-    assert np.any(arr > corner_reflector_threshold)
+    assert np.any(np.abs(arr) > corner_reflector_threshold)


### PR DESCRIPTION
This PR is to add a feature that applies static troposphere when weather model was not provided in runconfig. In case the weather model file is provided, the tropospheric correction is based on the weather model.
The static troposphere LUT can be calculated from incidence angle and surface height, which are calculated in `lut.py`.
