### PR TITLE
Placeholder for RFI information

### DIFF
--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -401,7 +401,7 @@ def metadata_to_h5group(parent_group, burst, cfg):
     # RFI information - placeholder
     rfi_items = [
         Meta('is_rfi_info_available', True,
-             'Whether RFI information is available'),
+             'Boolean variable specifying availability of RFI information'),
         Meta('rfi_mitigation_performed', '',
              'Whether or not the RFI mitigation step was performed'),
         Meta('rfi_mitigation_domain', '',

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -405,7 +405,8 @@ def metadata_to_h5group(parent_group, burst, cfg):
         Meta('rfi_mitigation_performed', '',
              'Whether or not the RFI mitigation step was performed'),
         Meta('rfi_mitigation_domain', '',
-             'in what domain the RFI mitigation step was performed'),
+             ('in what domain the RFI mitigation step was performed '
+              '["Time", "Frequency", "TimeAndFrequency"]')),
         Meta('rfi_burst_report', [],
              'Burst RFI report')]
     rfi_group = meta_group.require_group('rfi_information')

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -398,6 +398,20 @@ def metadata_to_h5group(parent_group, burst, cfg):
     # create metadata group to write datasets to
     meta_group = parent_group.require_group('metadata')
 
+    # RFI information - placeholder
+    rfi_items = [
+        Meta('is_rfi_info_available', True,
+             'Whether RFI information is available'),
+        Meta('rfi_mitigation_performed', '',
+             'Whether or not the RFI mitigation step was performed'),
+        Meta('rfi_mitigation_domain', '',
+             'in what domain the RFI mitigation step was performed'),
+        Meta('rfi_burst_report', [],
+             'Burst RFI report')]
+    rfi_group = meta_group.require_group('rfi_information')
+    for meta_item in rfi_items:
+        add_dataset_and_attrs(rfi_group, meta_item)
+
     # orbit items
     if 'orbit' in meta_group:
         del meta_group['orbit']


### PR DESCRIPTION
This PR adds placeholder for RFI information for CSLC output HDF5 file.
The structure of the metadata is based on the pending PR in `s1-reader` for RFI reader [here](https://github.com/opera-adt/s1-reader/pull/97)