### PR TITLE
use NETCDF to correctly get geotransform and projection

### DIFF
--- a/src/compass/utils/validate_cslc.py
+++ b/src/compass/utils/validate_cslc.py
@@ -54,7 +54,7 @@ def _gdal_nfo_retrieve(path_h5):
                 break
 
     # Extract some info from reference/secondary CSLC products with GDAL
-    h5_gdal_path = f'HDF5:{path_h5}://{grid_path}/{pol}'
+    h5_gdal_path = f'NETCDF:{path_h5}://{grid_path}/{pol}'
     dataset = gdal.Open(h5_gdal_path, gdal.GA_ReadOnly)
     geotransform = dataset.GetGeoTransform()
     proj = dataset.GetProjection()


### PR DESCRIPTION
This PR replaces HDF5 with NETCDF as the gdal prefix when using gdal to extract geotransform and projection from the raster.

The error was discovered @scottstanie. The following demonstrates why using `HDF5` as the gdal prefix is wrong and why using `NETCDF` is right.

Using `HDF5` as gdal prefix:
```
In [10]: ds = gdal.Open('HDF5:"stack-no-lut/t087_185682_iw1/20200101/t087_185682_iw1_20200101.h5"://science/SENTINEL1/CSLC/grids/VV')

In [11]: ds.GetGeoTransform()
Out[11]: (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)

In [12]: ds.GetProjection()
Out[12]: ''
```

Using `NETCDF` as gdal prefix:
```
In [14]: ds = gdal.Open('NETCDF:"stack-no-lut/t087_185682_iw1/20200101/t087_185682_iw1_20200101.h5"://science/SENTINEL1/CSLC/grids/VV')

In [15]: ds.GetGeoTransform()
Out[15]: (249650.0, 5.0, 0.0, 2178850.0, 0.0, -10.0)

In [16]: ds.GetProjection()
Out[16]: 'PROJCS["WGS 84 / UTM zone 5N",
```