### PR TITLE
0.1.3 -> 0.1.4

### DIFF
--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,6 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.1.4', '2023-03-23'),
     Tag('0.1.3', '2022-12-21'),
     Tag('0.1.2', '2022-07-21'),
     Tag('0.1.1', '2022-06-08'),


### PR DESCRIPTION
This PR is to update the version from `0.1.3` to `0.1.4` before cutting the release for gamma delivery.