### PR TITLE
geocode calibration parameters and noise LUTs

### DIFF
--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -183,8 +183,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
     ellipsoid = proj.ellipsoid
     burst_id = str(burst.burst_id)
     geo_grid = cfg.geogrids[burst_id]
-    radar_grid = burst.as_isce3_radargrid()
-
+    
     date_str = burst.sensing_start.strftime("%Y%m%d")
     burst_id_date_key = (burst_id, date_str)
     out_paths = cfg.output_paths[burst_id_date_key]
@@ -241,16 +240,15 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         # Define the radargrid for LUT interpolation
         # The resultant radargrid will have
         # the very first and the last LUT values be included.
-        radargrid_interp = radar_grid.copy()
+        radargrid_interp = burst.as_isce3_radargrid()
         #radargrid_interp = radargrid_interp.multilook(dec_factor[1], dec_factor[0])
 
         radargrid_interp.width = int(np.ceil(burst.width / dec_factor[0]))
-        range_px_interp_vec = np.linspace(0, burst.width, radargrid_interp.width)
+        range_px_interp_vec = np.linspace(0, burst.width - 1, radargrid_interp.width)
         intv_interp_range = range_px_interp_vec[1] - range_px_interp_vec[0]
 
-
         radargrid_interp.length = int(np.ceil(burst.length / dec_factor[1]))
-        azimuth_px_interp_vec = np.linspace(0, burst.length, radargrid_interp.length)
+        azimuth_px_interp_vec = np.linspace(0, burst.length - 1, radargrid_interp.length)
         intv_interp_azimuth = azimuth_px_interp_vec[1] - azimuth_px_interp_vec[0]
 
         if az_lut_grid is not None:

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -156,7 +156,7 @@ def run(cfg, burst, fetch_from_scratch=False):
 
 
 def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
-                 dec_factor_x_rng=20 . dec_factor_y_az=5):
+                 dec_factor_x_rng=20, dec_factor_y_az=5):
     '''
     Geocode the radiometric calibratio paremeters,
     and write them into output HDF5.
@@ -200,10 +200,10 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
     decimated_geogrid = isce3.product.GeoGridParameters(
                             geo_grid.start_x,
                             geo_grid.start_y,
-                            geo_grid.spacing_x * dec_factor[0],
-                            geo_grid.spacing_y * dec_factor[1],
-                            geo_grid.width // dec_factor[0],
-                            geo_grid.length // dec_factor[1],
+                            geo_grid.spacing_x * dec_factor_x_rng,
+                            geo_grid.spacing_y * dec_factor_y_az,
+                            int(np.ceil(geo_grid.width // dec_factor_x_rng)),
+                            int(np.ceil(geo_grid.length // dec_factor_y_az)),
                             geo_grid.epsg)
 
     # initialize geocode object
@@ -244,11 +244,11 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         # The resultant radargrid will have
         # the very first and the last LUT values be included.
         radargrid_interp = burst.as_isce3_radargrid()
-        radargrid_interp.width = int(np.ceil(burst.width / dec_factor[0]))
+        radargrid_interp.width = int(np.ceil(burst.width / dec_factor_x_rng))
         range_px_interp_vec = np.linspace(0, burst.width - 1, radargrid_interp.width)
         intv_interp_range = range_px_interp_vec[1] - range_px_interp_vec[0]
 
-        radargrid_interp.length = int(np.ceil(burst.length / dec_factor[1]))
+        radargrid_interp.length = int(np.ceil(burst.length / dec_factor_y_az))
         azimuth_px_interp_vec = np.linspace(0, burst.length - 1, radargrid_interp.length)
         intv_interp_azimuth = azimuth_px_interp_vec[1] - azimuth_px_interp_vec[0]
 
@@ -307,7 +307,8 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
 
 
 def geocode_calibration_luts(geo_burst_h5, burst, cfg,
-                             dec_factor=(20, 5)):
+                             dec_factor_x_rng=20,
+                             dec_factor_y_az=5):
     '''
     Geocode the radiometric calibratio paremeters,
     and write them into output HDF5.
@@ -320,9 +321,12 @@ def geocode_calibration_luts(geo_burst_h5, burst, cfg,
         Sentinel-1 burst SLC
     cfg: GeoRunConfig
         GeoRunConfig object with user runconfig options
-    dec_factor: tuple
+    dec_factor_x_rg: int
         Decimation factor to downsample the LUT in
-        range and azimuth direction respectively
+        x or range direction
+    dec_factor_y_az: int
+        Decimation factor to downsample the LUT in
+        y or azimuth direction
     '''
     dst_group_path = f'{ROOT_PATH}/metadata/calibration_information'
 
@@ -345,11 +349,13 @@ def geocode_calibration_luts(geo_burst_h5, burst, cfg,
               None]
         }
     geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict_calibration,
-                 dec_factor)
+                 dec_factor_x_rng,
+                 dec_factor_y_az)
 
 
 def geocode_noise_luts(geo_burst_h5, burst, cfg,
-                       dec_factor=(20, 5)):
+                       dec_factor_x_rng=20,
+                       dec_factor_y_az=5):
     '''
     Geocode the noise LUT, and write that into output HDF5.
 
@@ -361,9 +367,12 @@ def geocode_noise_luts(geo_burst_h5, burst, cfg,
         Sentinel-1 burst SLC
     cfg: GeoRunConfig
         GeoRunConfig object with user runconfig options
-    dec_factor: tuple
+    dec_factor_x_rg: int
         Decimation factor to downsample the LUT in
-        range and azimuth direction respectively
+        x or range direction
+    dec_factor_y_az: int
+        Decimation factor to downsample the LUT in
+        y or azimuth direction
     '''
     dst_group_path =  f'{ROOT_PATH}/metadata/noise_information'
     item_dict_noise = {'thermal_noise_lut': [burst.burst_noise.range_pixel,
@@ -372,7 +381,8 @@ def geocode_noise_luts(geo_burst_h5, burst, cfg,
                                        burst.burst_noise.azimuth_lut]
                                        }
     geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict_noise,
-                 dec_factor)
+                 dec_factor_x_rng,
+                 dec_factor_y_az)
 
 
 if __name__ == "__main__":

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -156,7 +156,7 @@ def run(cfg, burst, fetch_from_scratch=False):
 
 
 def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
-                 dec_factor=(20, 5)):
+                 dec_factor_x_rng=20 . dec_factor_y_az=5):
     '''
     Geocode the radiometric calibratio paremeters,
     and write them into output HDF5.
@@ -173,9 +173,12 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         Path in HDF5 where geocode rasters will be placed
     item_dict: dict
         Dict containing item names and values to be geocoded
-    dec_factor: tuple
+    dec_factor_x_rg: int
         Decimation factor to downsample the LUT in
-        range and azimuth direction respectively
+        x or range direction
+    dec_factor_y_az: int
+        Decimation factor to downsample the LUT in
+        y or azimuth direction
     '''
     dem_raster = isce3.io.Raster(cfg.dem)
     epsg = dem_raster.get_epsg()

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -237,6 +237,8 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
                 f"IH5:::ID={dst_dataset.id.id}".encode("utf-8"), update=True)
 
         # Define the radargrid for LUT interpolation
+        # The resultant radargrid will have
+        # the very first and the last LUT values be included.
         radargrid_interp = radar_grid.copy()
 
         radargrid_interp.width = int(np.ceil(burst.width / dec_factor))

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -249,7 +249,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
 
         radargrid_interp.range_pixel_spacing *= intv_interp_range
         radargrid_interp.prf /= intv_interp_azimuth
-        
+
         # Get the interpolated range LUT
         param_interp_obj = InterpolatedUnivariateSpline(lut_rgaz[0],
                                                         lut_rgaz[1],
@@ -317,11 +317,23 @@ def geocode_calibration_luts(geo_burst_h5, burst, cfg,
     '''
     dst_group_path = f'{ROOT_PATH}/metadata/calibration_information'
 
-    #[Range grid of the source in pixel. range LUT value, azimuth grid of the source in pixel, azimuth LUT value],
+    #[Range grid of the source in pixel,
+    # range LUT value,
+    # azimuth grid of the source in pixel,
+    # azimuth LUT value]
     item_dict_calibration = {
-        'gamma':[burst.burst_calibration.pixel, burst.burst_calibration.gamma, None, None],
-        'sigma_naught':[burst.burst_calibration.pixel, burst.burst_calibration.sigma_naught, None, None],
-        'dn':[burst.burst_calibration.pixel, burst.burst_calibration.dn, None, None]
+        'gamma':[burst.burst_calibration.pixel,
+                 burst.burst_calibration.gamma,
+                 None,
+                 None],
+        'sigma_naught':[burst.burst_calibration.pixel,
+                        burst.burst_calibration.sigma_naught,
+                        None,
+                        None],
+        'dn':[burst.burst_calibration.pixel,
+              burst.burst_calibration.dn,
+              None,
+              None]
         }
     geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict_calibration,
                  dec_factor)

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -221,7 +221,8 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         geo_burst_h5.require_group(dst_group_path)
 
     gdal_envi_driver = gdal.GetDriverByName('ENVI')
-    for item_name, lut_rgaz in item_dict.items():
+    for item_name, (rg_lut_grid, rg_lut_val,
+                    az_lut_grid, az_lut_val) in item_dict.items():
         # prepare input dataset in output HDF5
         init_geocoded_dataset(dst_group,
                               item_name,
@@ -253,17 +254,17 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         radargrid_interp.prf /= intv_interp_azimuth
 
         # Get the interpolated range LUT
-        param_interp_obj = InterpolatedUnivariateSpline(lut_rgaz[0],
-                                                        lut_rgaz[1],
+        param_interp_obj = InterpolatedUnivariateSpline(rg_lut_grid,
+                                                        rg_lut_val,
                                                         k=1)
         range_lut_interp = param_interp_obj(range_px_interp_vec)
 
         # Get the interpolated azimuth LUT
-        if lut_rgaz[2] is None or lut_rgaz[3] is None:
+        if az_lut_grid is None or az_lut_val is None:
             azimuth_lut_interp = np.ones(radargrid_interp.length)
         else:
-            param_interp_obj = InterpolatedUnivariateSpline(lut_rgaz[2],
-                                                            lut_rgaz[3],
+            param_interp_obj = InterpolatedUnivariateSpline(az_lut_grid,
+                                                            az_lut_val,
                                                             k=1)
             azimuth_lut_interp = param_interp_obj(azimuth_px_interp_vec)
 

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -156,7 +156,7 @@ def run(cfg, burst, fetch_from_scratch=False):
 
 
 def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
-                 dec_factor=(40, 10)):
+                 dec_factor=(20, 5)):
     '''
     Geocode the radiometric calibratio paremeters,
     and write them into output HDF5.
@@ -240,21 +240,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         # Define the radargrid for LUT interpolation
         # The resultant radargrid will have
         # the very first and the last LUT values be included.
-
         radargrid_interp = burst.as_isce3_radargrid()
-        # Extract burst boundaries
-        
-        # Create sliced radar grid representing valid region of the burst
-        
-
-        # Method 1: Use multilook()
-        '''radargrid_interp = radargrid_interp.multilook(dec_factor[1], dec_factor[0])
-        range_px_interp_vec = np.linspace(0, burst.width - 1, radargrid_interp.width)
-        azimuth_px_interp_vec = np.linspace(0, burst.length - 1, radargrid_interp.length)'''
-
-        
-
-        # Method 2: Custom calculation of the decimated radargrid
         radargrid_interp.width = int(np.ceil(burst.width / dec_factor[0]))
         range_px_interp_vec = np.linspace(0, burst.width - 1, radargrid_interp.width)
         intv_interp_range = range_px_interp_vec[1] - range_px_interp_vec[0]
@@ -266,15 +252,8 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         radargrid_interp.range_pixel_spacing *= intv_interp_range
         radargrid_interp.prf /= intv_interp_azimuth
 
-
-
-
         if az_lut_grid is not None:
             azimuth_px_interp_vec += az_lut_grid[0]
-
-
-
-
 
         # Get the interpolated range LUT
         param_interp_obj_rg = InterpolatedUnivariateSpline(rg_lut_grid,
@@ -305,8 +284,6 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         lut_gdal_raster = None
 
         input_raster = isce3.io.Raster(lut_path)
-
-
 
         # geocode then set transfrom and EPSG in output raster
         geocode_obj.geocode(radar_grid=radargrid_interp,

--- a/src/compass/utils/radar_grid.py
+++ b/src/compass/utils/radar_grid.py
@@ -1,3 +1,4 @@
+import numpy as np
 import isce3
 
 
@@ -35,3 +36,39 @@ def rdr_grid_to_file(ref_grid_path: str,
         f_rdr_grid.write(str(rdr_grid.length) + '\n')
         f_rdr_grid.write(str(rdr_grid.width) + '\n')
         f_rdr_grid.write(str(rdr_grid.ref_epoch) + '\n')
+
+
+def get_decimated_rdr_grd(rdr_grid_original,
+                          dec_factor_rng,
+                          dec_factor_az) -> isce3.product.RadarGridParameters:
+    '''
+    Decimate the `rdr_grid_original` by the factor close to
+    `dec_factor_rng` and `dec_factor_az` in range / azimuth direction respectively,
+    while making sure that the very first / last samples / lines in
+    `rdr_grid_original` gets included in the result.
+
+    Parameters
+    ----------
+    rdr_grid_original: isce3.product.RadarGridParameters
+        The original radargrid as the basis of the decimated radargrid
+    dec_factor_rng: int
+        Decimation factor in range direction
+    dec_factor_az: int
+        Decimation factor in azimuth direction
+
+    Returns
+    -------
+    rdr_grid_decimated: isce3.product.RadarGridParameters
+        Decimated radar grid
+    '''
+    rdr_grid_decimated = rdr_grid_original.copy()
+    rdr_grid_decimated.width = int(np.ceil(rdr_grid_original.width / dec_factor_rng))
+    interval_rng = (rdr_grid_original.width - 1) / (rdr_grid_decimated.width - 1)
+
+    rdr_grid_decimated.length = int(np.ceil(rdr_grid_original.length / dec_factor_az))
+    interval_az = (rdr_grid_original.length - 1) / (rdr_grid_decimated.length - 1)
+
+    rdr_grid_decimated.range_pixel_spacing *= interval_rng
+    rdr_grid_decimated.prf /= interval_az
+
+    return rdr_grid_decimated


### PR DESCRIPTION
This is a follow-up of #114 #119, which were the placeholders for the geocoded radiometric calibration parameters, and thermal noise LUTs respectively. This loads the calibration parameter LUTs from `Sentinel1BurstSLC`, geocode them, and write that into the output.