### PR TITLE
Remove is_urgent_observation metadata

### DIFF
--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -378,8 +378,6 @@ def identity_to_h5group(dst_group, burst, cfg):
         Meta('zero_doppler_end_time', burst.sensing_stop.strftime(TIME_STR_FMT),
             'Azimuth stop time of product'),
         Meta('is_geocoded', 'True', 'Boolean indicating if product is in radar geometry or geocoded'),
-        Meta('is_urgent_observation', 'False',
-             'Boolean indicating if data take is a urgent observation'),
         ]
     id_group = dst_group.require_group('identification')
     for meta_item in id_meta_items:


### PR DESCRIPTION
We do not have any urgent observation for CSLC. This metadata entry is inherited from NISAR and probably it does not make sense for production. 