### PR TITLE
 Fix license/classifiers metadata in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,11 @@ description = A Package to Generate Coregistered Multi-temporal SAR SLC
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/opera-adt/COMPASS
+license_file = LICENSE
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Science/Research
     Programming Language :: Python :: 3
-    License = file : LICENSE
     Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
If you try to upload this to pypi, its rejected with the error: WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
         Invalid value for classifiers.
         Error: Classifier 'License = file : LICENSE' is not a valid classifier.

Fix comes from here:
https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata