### PR TITLE
validate_cslc -> validate_product

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ where = src
 console_scripts =
     s1_cslc.py = compass.s1_cslc:main
     s1_geocode_stack.py = compass.s1_geocode_stack:main
-    validate_cslc.py = compass.utils.validate_cslc:main
+    validate_product.py = compass.utils.validate_product:main


### PR DESCRIPTION
This PR is to update `setup.cfg` so that the validation script can be installed properly. This update is due to the file name change in the PR #124 that extends the validation script to work for static layer files as well as the CSLC output.