### PR TITLE
save only 6 digits of datetime in orbit metadata

### DIFF
--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -293,7 +293,8 @@ def save_orbit(orbit, orbit_direction, orbit_group):
     orbit_group: h5py.Group
         HDF5 group where orbit parameters will be written
     '''
-    ref_epoch = orbit.reference_epoch.isoformat().replace('T', ' ')
+    # isce isoformat gives 9 decimal places, but python `fromisoformat` wants 6
+    ref_epoch = orbit.reference_epoch.isoformat().replace('T', ' ')[:-3]
     orbit_items = [
         Meta('reference_epoch', ref_epoch, 'Reference epoch of the state vectors',
              {'format': 'YYYY-MM-DD HH:MM:SS.6f'}),


### PR DESCRIPTION
```
>>> import isce3, datetime
>>> isce3.core.DateTime(datetime.datetime(2022, 11, 20, 16, 16, 43, 152613)).isoformat()

'2022-11-20T16:16:43.152613000'
```

the current orbit description says
> description: b'Reference epoch of the state vectors, format: b'YYYY-MM-DD HH:MM:SS.6f'

but isce's `isoformat` gives 9 digits, so it fails `datetime.datetime.fromisoformat` but would also fail if a user looked at the description to parse it