### PR TITLE
Add product specification version to CSLC product

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -36,6 +36,8 @@ runconfig:
           sas_output_file:
           # Product version
           product_version: 0.2
+          # Product specification document version
+          product_specification_version: 0.1.5
 
       primary_executable:
           product_type: CSLC_S1

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -36,6 +36,8 @@ runconfig:
            sas_output_file: str()
            # Product version
            product_version: num(required=False)
+           # Product specification document version
+           product_specification_version: num(required=False)
 
         primary_executable:
           product_type: enum('CSLC_S1')

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -362,9 +362,11 @@ def identity_to_h5group(dst_group, burst, cfg):
     # identification datasets
     id_meta_items = [
         Meta('product_version', f'{cfg.product_group.product_version}', 'CSLC-S1 product version'),
+        Meta('product_specification_version', f'{cfg.product_group.product_specification_version}',
+             'CSLC-S1 product specification version'),
         Meta('absolute_orbit_number', burst.abs_orbit_number, 'Absolute orbit number'),
         Meta('track_number', burst.burst_id.track_number, 'Track number'),
-        Meta('burst_id', str(burst.burst_id), 'Burst identification (burst ID)'),
+        Meta('burst_id', str(burst.burst_id), 'Burst identification string (burst ID)'),
         Meta('bounding_polygon', get_polygon_wkt(burst),
              'OGR compatible WKT representation of bounding polygon of the image',
              {'units':'degrees'}),


### PR DESCRIPTION
This PR adds the product specification version to the CSLC-S1 product. The version of the product specification document can be assigned from the runconfiguration file and it is exposed at the PGE/ADT interface