### PR TITLE
Option to `s1_rdr2geo` to process a single burst

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -94,7 +94,7 @@ def run(cfg: GeoRunConfig):
 
         # Generate required static layers
         if cfg.rdr2geo_params.enabled:
-            s1_rdr2geo.run(cfg, save_in_scratch=True)
+            s1_rdr2geo.run(cfg, burst, save_in_scratch=True)
             if cfg.rdr2geo_params.geocode_metadata_layers:
                 s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
 

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -16,13 +16,15 @@ from compass.utils.runconfig import RunConfig
 from compass.utils.yaml_argparse import YamlArgparse
 
 
-def run(cfg, save_in_scratch=False):
+def run(cfg, burst=None, save_in_scratch=False):
     '''run rdr2geo with provided runconfig
 
     Parameters
     ----------
     cfg: dict
         Runconfig dictionary with user-defined options
+    burst: Sentinel1BurstSlc
+        Burst to run rdr2geo. If `None`, it will process all bursts in `cfg`
     save_in_scratch: bool
         Flag to save output in scratch dir instead of product dir
     '''
@@ -57,7 +59,12 @@ def run(cfg, save_in_scratch=False):
 
     # run rdr2geo for only once per burst_id
     # save SLC for all bursts
-    for burst in cfg.bursts:
+    if burst is None:
+        bursts = cfg.bursts
+    else:
+        bursts = [burst]
+
+    for burst in bursts:
         # extract date string and create directory
         date_str = burst.sensing_start.strftime("%Y%m%d")
         burst_id = str(burst.burst_id)


### PR DESCRIPTION
This PR adds an option to `s1_rdr2geo` to process a single burst. This is enabled by adding a parameter `burst` to `s1_rdr2geo.run`. If this parameter is not specified, then `s1_rdr2geo.run` will process all bursts in `cfg`.