### PR TITLE
Optimization of function call `make_browse_image`

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -191,7 +191,7 @@ def run(cfg: GeoRunConfig):
             browse_params = cfg.browse_image_params
             if browse_params.enabled:
                 make_browse_image(out_paths.browse_path, output_hdf5,
-                                  cfg.bursts, browse_params.complex_to_real,
+                                  bursts, browse_params.complex_to_real,
                                   browse_params.percent_low,
                                   browse_params.percent_high,
                                   browse_params.gamma, browse_params.equalize)


### PR DESCRIPTION
This PR address the issue regarding the runtime when generating browse image. The browse image is generated by using `make_browse_image` in `s1_geocode_slc`. Currently the function takes `cfg.bursts` as input, so that the browse images for all input bursts are generated in each burst for loop. This PR replaces `cfg.bursts` into `bursts` so that the browse image is generated only for the corresponding bursts in the loop.