### PR TITLE
Remove azimuth carrier and add flattening ramps for AGE

### DIFF
--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -292,12 +292,12 @@ def find_peak(cslc_file, x_loc, y_loc, mission_id='S1',
     # If True, remove azimuth carrier ramp
     if apply_az_ramp:
         carrier_phase = get_carrier_phase(cslc_file, mission_id=mission_id)
-        arr *= np.exp(-1j*carrier_phase)
+        arr *= np.exp(-1j * carrier_phase)
 
     # If True, adds back flattening phase
     if unflatten:
         flatten_phase = get_flatten_phase(cslc_file, mission_id=mission_id)
-        arr *= np.exp(-1j*flatten_phase)
+        arr *= np.exp(-1j * flatten_phase)
 
     x_start, x_spac, y_start, y_spac = get_xy_info(cslc_file,
                                                    mission_id=mission_id,
@@ -338,7 +338,7 @@ def find_peak(cslc_file, x_loc, y_loc, mission_id='S1',
     return x_cr, y_cr, snr_cr_db
 
 
-def get_carrier_phase(cslc_file, mission_id ='S1'):
+def get_carrier_phase(cslc_file, mission_id='S1'):
     '''
     Get azimuth carrier phase from CSLC product
     Note, this is implemented only for CSLC-S1
@@ -358,7 +358,7 @@ def get_carrier_phase(cslc_file, mission_id ='S1'):
     '''
 
     if mission_id == 'S1':
-        carrier_path = 'science/SENTINEL1/CSLC/grids/carrier_phase'
+        carrier_path = f'{DATA_PATH}/azimuth_carrier_phase'
     else:
         err_str = f"Azimuth carrier phase not present for {mission_id} CSLC product"
         raise ValueError(err_str)
@@ -388,7 +388,7 @@ def get_flatten_phase(cslc_file, mission_id='S1'):
     '''
 
     if mission_id == 'S1':
-        rg_off_path = 'science/SENTINEL1/CSLC/grids/range_offset'
+        rg_off_path = f'{DATA_PATH}/flattening_phase'
     else:
         err_str = f"Range offsets not present for {mission_id} CSLC product"
         raise ValueError(err_str)

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -469,13 +469,13 @@ def get_xy_info(cslc_file, mission_id='S1', pol='VV'):
     if mission_id == 'S1':
         cslc_path = DATA_PATH
     elif mission_id == 'NI':
-        cslc_path = '/science/LSAR/GSLC/grids/frequencyA/'
+        cslc_path = '/science/LSAR/GSLC/grids/frequencyA'
     else:
         err_str = f'{mission_id} is not a valid mission identifier'
         raise ValueError(err_str)
 
     # Open geocoded SLC with a NetCDF driver
-    ds_in = gdal.Open(f'NETCDF:{cslc_file}:{cslc_path}{pol}')
+    ds_in = gdal.Open(f'NETCDF:{cslc_file}:{cslc_path}/{pol}')
 
     geo_trans = ds_in.GetGeoTransform()
     x_spac = geo_trans[1]

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -293,7 +293,7 @@ def find_peak(cslc_file, x_loc, y_loc, mission_id='S1',
     # If True, adds back flattening phase
     if unflatten:
         flatten_phase = get_flatten_phase(cslc_file, mission_id=mission_id)
-        arr *= np.exp(1j*flatten_phase)
+        arr *= np.exp(-1j*flatten_phase)
 
     x_start, x_spac, y_start, y_spac = get_xy_info(cslc_file,
                                                    mission_id=mission_id,
@@ -351,7 +351,7 @@ def get_carrier_phase(cslc_file, mission_id ='S1'):
     '''
 
     if mission_id == 'S1':
-        carrier_path = 'science/SENTINEL1/CSLC/grids/azimuth_carrier_phase'
+        carrier_path = 'science/SENTINEL1/CSLC/grids/carrier_phase'
     else:
         err_str = f"Azimuth carrier phase not present for {mission_id} CSLC product"
         raise ValueError(err_str)
@@ -382,16 +382,13 @@ def get_flatten_phase(cslc_file, mission_id='S1'):
 
     if mission_id == 'S1':
         rg_off_path = 'science/SENTINEL1/CSLC/grids/range_offset'
-        wavelength_path = '/science/SENTINEL1/CSLC/metadata/processing_information/s1_burst_metadata/wavelength'
     else:
         err_str = f"Range offsets not present for {mission_id} CSLC product"
         raise ValueError(err_str)
 
     with h5py.File(cslc_file, 'r') as h5:
-        rg_off = h5[rg_off_path][()]
-        wavelength = h5[wavelength_path][()]
+        flatten_phase = h5[rg_off_path][()]
 
-    flatten_phase = (4.0*np.pi*rg_off)/wavelength
     return flatten_phase
 
 

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -666,7 +666,7 @@ def create_parser():
                           help='Padding margin around CR position detected in the geocoded SLC '
                                'image. Actual margin is 2*margin from left-to-right and from'
                                'top-to-bottom')
-    optional.add_argument('-r', '--azimuth-ramp', dest='az_ramp', default=True,
+    optional.add_argument('-r', '--azimuth-ramp', dest='apply_az_ramp', default=True,
                           help='If True, removes azimuth carrier ramp prior to CR peak location. '
                                'This option should be set to True for S1-A/B AGE analyses')
     optional.add_argument('-u', '--unflatten', dest='unflatten', default=True,
@@ -690,7 +690,7 @@ def main():
         pol=args.pol,
         ovs_factor=args.ovs_factor,
         margin=args.margin,
-        apply_az_ramp=args.az_ramp,
+        apply_az_ramp=args.apply_az_ramp,
         unflatten=args.unflatten)
 
 


### PR DESCRIPTION
**This PR has been successfully tested to compute the absolute geolocation for Rosamond. It is awaiting further development in COMPASS **.

This PR adds the options to:
1. Remove the azimuth carrier phase ramp (for CSLC-S1 only)
2. Add back the flattening phase ramp 

when analyzing the absolute geolocation performance of CSLC-S1 products.
At the moment, the implementation supports CSLC-S1 only and will include CSLC-NI (GSLC) in a later stage.

According to our analyses:
1. Azimuth carrier ramp needs to be added back to CSLC-S1 to have meaningful interferograms. Therefore, the ramp should be removed when computing AGE as it affects AGE performance
2. As per current baseline, CSLC-S1 (and NISAR GSLC) will be flattened. Flattening phase ramp needs to be added back to avoid aliasing prior to oversampling the peak for AGE determination