### PR TITLE
Remove /science/SENTINEL1 from CSLC-S1 and static layers

### DIFF
--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import isce3
 import numpy as np
 
-from compass.utils.h5_helpers import (GRID_PATH, QA_PATH, ROOT_PATH,
+from compass.utils.h5_helpers import (DATA_PATH, QA_PATH, ROOT_PATH,
                                       add_dataset_and_attrs, Meta)
 
 
@@ -63,7 +63,7 @@ class QualityAssuranceCSLC:
             pol = b.polarization
 
             # get dataset and compute stats according to dtype
-            pol_path = f'{GRID_PATH}/{pol}'
+            pol_path = f'{DATA_PATH}/{pol}'
             pol_ds = cslc_h5py_root[pol_path]
 
             # compute stats for real and complex
@@ -117,7 +117,7 @@ class QualityAssuranceCSLC:
             apply_tropo_corrections is true.
         '''
         # path to source group
-        static_layer_path = f'{GRID_PATH}/static_layers'
+        static_layer_path = f'{DATA_PATH}/static_layers'
 
         # Get the static layer to compute stats for
         static_layers_dict = {

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -8,8 +8,7 @@ import isce3
 import numpy as np
 
 from compass.utils.h5_helpers import (DATA_PATH, METADATA_PATH,
-                                      QA_PATH, ROOT_PATH,
-                                      add_dataset_and_attrs, Meta)
+                                      QA_PATH, add_dataset_and_attrs, Meta)
 
 
 def value_description_dict(val, desc):

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import isce3
 import numpy as np
 
-from compass.utils.h5_helpers import (DATA_PATH, QA_PATH, ROOT_PATH,
+from compass.utils.h5_helpers import (DATA_PATH, METADATA_PATH,
+                                      QA_PATH, ROOT_PATH,
                                       add_dataset_and_attrs, Meta)
 
 
@@ -155,7 +156,7 @@ class QualityAssuranceCSLC:
             apply_tropo_corrections is true.
         '''
         # path to source group
-        corrections_src_path = f'{ROOT_PATH}/corrections'
+        corrections_src_path = f'{METADATA_PATH}/processing_information/timing_corrections'
 
         # names of datasets to compute stats for
         corrections = ['bistatic_delay', 'geometry_steering_doppler',
@@ -170,7 +171,7 @@ class QualityAssuranceCSLC:
 
         self.compute_stats_from_float_hdf5_dataset(cslc_h5py_root,
                                                    corrections_src_path,
-                                                   'corrections', corrections)
+                                                   'timing_corrections', corrections)
 
 
     def compute_stats_from_float_hdf5_dataset(self, cslc_h5py_root,

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -81,7 +81,7 @@ class QualityAssuranceCSLC:
 
                 # create HDF5 group for real/imaginary stats of current
                 # polarization
-                h5_stats_path = f'{QA_PATH}/statistics/grids/{pol}/{real_imag}'
+                h5_stats_path = f'{QA_PATH}/statistics/data/{pol}/{real_imag}'
                 stats_group = cslc_h5py_root.require_group(h5_stats_path)
 
                 # add description for stat items

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -16,6 +16,7 @@ from compass.s1_cslc_qa import QualityAssuranceCSLC
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.h5_helpers import (init_geocoded_dataset,
                                       metadata_to_h5group, DATA_PATH,
+                                      METADATA_PATH,
                                       ROOT_PATH)
 from compass.utils.helpers import bursts_grouping_generator, get_module_name
 from compass.utils.yaml_argparse import YamlArgparse
@@ -288,7 +289,7 @@ def geocode_calibration_luts(geo_burst_h5, burst, cfg,
     dec_factor: int
         Decimation factor to downsample the slant range pixels for LUT
     '''
-    dst_group_path = f'{ROOT_PATH}/metadata/calibration_information'
+    dst_group_path = f'{METADATA_PATH}/calibration_information'
     item_dict = {'gamma':burst.burst_calibration.gamma,
                  'sigma_naught':burst.burst_calibration.sigma_naught,
                  'dn':burst.burst_calibration.dn}
@@ -312,7 +313,7 @@ def geocode_noise_luts(geo_burst_h5, burst, cfg,
     dec_factor: int
         Decimation factor to downsample the slant range pixels for LUT
     '''
-    dst_group_path =  f'{ROOT_PATH}/metadata/noise_information'
+    dst_group_path =  f'{METADATA_PATH}/noise_information'
     item_dict = {'thermal_noise_lut': None}
     geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
                  dec_factor)

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -15,7 +15,7 @@ from compass import s1_rdr2geo
 from compass.s1_cslc_qa import QualityAssuranceCSLC
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.h5_helpers import (init_geocoded_dataset,
-                                      metadata_to_h5group, GRID_PATH,
+                                      metadata_to_h5group, DATA_PATH,
                                       ROOT_PATH)
 from compass.utils.helpers import bursts_grouping_generator, get_module_name
 from compass.utils.yaml_argparse import YamlArgparse
@@ -97,9 +97,9 @@ def run(cfg, burst, fetch_from_scratch=False):
 
     out_h5 = f'{out_paths.output_directory}/static_layers_{burst_id}.h5'
     with h5py.File(out_h5, 'w') as h5_obj:
-        # Create group static_layers group under GRID_PATH for consistency with
+        # Create group static_layers group under DATA_PATH for consistency with
         # CSLC product
-        static_layer_group = h5_obj.require_group(f'{GRID_PATH}/static_layers')
+        static_layer_group = h5_obj.require_group(f'{DATA_PATH}/static_layers')
 
         # Geocode designated layers
         for layer_name, enabled in meta_layers.items():

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -108,7 +108,7 @@ def run(cfg: GeoRunConfig):
         sliced_radar_grid = burst.as_isce3_radargrid()[b_bounds]
 
         output_hdf5 = out_paths.hdf5_path
-        root_path = '/science/SENTINEL1'
+
         with h5py.File(output_hdf5, 'w') as geo_burst_h5:
             geo_burst_h5.attrs['Conventions'] = "CF-1.8"
             geo_burst_h5.attrs["contact"] = np.string_("operaops@jpl.nasa.gov")
@@ -121,7 +121,7 @@ def run(cfg: GeoRunConfig):
             ctype = h5py.h5t.py_create(np.complex64)
             ctype.commit(geo_burst_h5['/'].id, np.string_('complex64'))
 
-            grid_path = f'{root_path}/CSLC/grids'
+            grid_path = f'/CSLC/data'
             grid_group = geo_burst_h5.require_group(grid_path)
             check_eap = is_eap_correction_necessary(burst.ipf_version)
             for b in bursts:
@@ -175,10 +175,11 @@ def run(cfg: GeoRunConfig):
         # Save burst corrections and metadata with new h5py File instance
         # because io.Raster things
         with h5py.File(output_hdf5, 'a') as geo_burst_h5:
+            root_path = '/'
             root_group = geo_burst_h5[root_path]
             identity_to_h5group(root_group, burst, cfg)
 
-            cslc_group = geo_burst_h5.require_group(f'{root_path}/CSLC')
+            cslc_group = geo_burst_h5.require_group(f'/CSLC')
             metadata_to_h5group(cslc_group, burst, cfg)
             if cfg.lut_params.enabled:
                 corrections_to_h5group(cslc_group, burst, cfg, rg_lut, az_lut,

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -121,7 +121,7 @@ def run(cfg: GeoRunConfig):
             ctype = h5py.h5t.py_create(np.complex64)
             ctype.commit(geo_burst_h5['/'].id, np.string_('complex64'))
 
-            data_path = f'/CSLC/data'
+            data_path = '/CSLC/data'
             grid_group = geo_burst_h5.require_group(data_path)
             check_eap = is_eap_correction_necessary(burst.ipf_version)
             for b in bursts:
@@ -179,7 +179,7 @@ def run(cfg: GeoRunConfig):
             root_group = geo_burst_h5[root_path]
             identity_to_h5group(root_group, burst, cfg)
 
-            cslc_group = geo_burst_h5.require_group(f'/CSLC')
+            cslc_group = geo_burst_h5.require_group('/CSLC')
             metadata_to_h5group(cslc_group, burst, cfg)
             if cfg.lut_params.enabled:
                 corrections_to_h5group(cslc_group, burst, cfg, rg_lut, az_lut,

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -121,8 +121,8 @@ def run(cfg: GeoRunConfig):
             ctype = h5py.h5t.py_create(np.complex64)
             ctype.commit(geo_burst_h5['/'].id, np.string_('complex64'))
 
-            grid_path = f'/CSLC/data'
-            grid_group = geo_burst_h5.require_group(grid_path)
+            data_path = f'/CSLC/data'
+            grid_group = geo_burst_h5.require_group(data_path)
             check_eap = is_eap_correction_necessary(burst.ipf_version)
             for b in bursts:
                 pol = b.polarization

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -3,7 +3,6 @@
 '''wrapper for rdr2geo'''
 
 from datetime import timedelta
-import os
 import time
 
 import isce3

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -11,7 +11,8 @@ import shapely.wkt as wkt
 from osgeo import gdal, osr
 from pyproj import CRS, Proj
 from shapely import geometry
-from compass.utils.h5_helpers import DATA_PATH
+from compass.utils.h5_helpers import (DATA_PATH,
+                                      METADATA_PATH)
 
 dateformat = '%Y-%m-%d %H:%M:%S.%f'
 
@@ -193,8 +194,8 @@ def correct_cr_tides(cslc_file, cr_lat, cr_lon,
     import pysolid
     # Get geocode SLC sensing start and stop
     if mission_id == 'S1':
-        start_path = '/CSLC/metadata/processing_information/s1_burst_metadata/sensing_start'
-        stop_path = '/CSLC/metadata/processing_information/s1_burst_metadata/sensing_stop'
+        start_path = f'{METADATA_PATH}/processing_information/s1_burst_metadata/sensing_start'
+        stop_path = f'{METADATA_PATH}/processing_information/s1_burst_metadata/sensing_stop'
     elif mission_id == 'NI':
         start_path = '/science/LSAR/GSLC/identification/zeroDopplerStartTime'
         stop_path = '/science/LSAR/GSLC/identification/zeroDopplerEndTime'

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -11,6 +11,7 @@ import shapely.wkt as wkt
 from osgeo import gdal, osr
 from pyproj import CRS, Proj
 from shapely import geometry
+from compass.utils.h5_helpers import DATA_PATH
 
 dateformat = '%Y-%m-%d %H:%M:%S.%f'
 
@@ -323,7 +324,7 @@ def get_cslc(cslc_file, mission_id='S1', pol='VV'):
     '''
 
     if mission_id == 'S1':
-        cslc_path = f'CSLC/data/{pol}'
+        cslc_path = f'{DATA_PATH}/{pol}'
     elif mission_id == 'NI':
         with h5py.File(cslc_file, 'r') as h5:
              frequencies = h5["/science/LSAR/identification/listOfFrequencies"][()]
@@ -368,7 +369,7 @@ def get_xy_info(cslc_file, mission_id='S1', pol='VV'):
         CSLC-S1 spacing along Y-direction
     '''
     if mission_id == 'S1':
-        cslc_path = 'CSLC/data/'
+        cslc_path = DATA_PATH
     elif mission_id == 'NI':
         cslc_path = '/science/LSAR/GSLC/grids/frequencyA/'
     else:
@@ -473,7 +474,7 @@ def get_cslc_epsg(cslc_file, mission_id='S1', pol='VV'):
         geocoded SLC product
     '''
     if mission_id == 'S1':
-        epsg_path = 'CSLC/data/projection'
+        epsg_path = f'{DATA_PATH}/projection'
         with h5py.File(cslc_file, 'r') as h5:
             epsg = h5[epsg_path][()]
     elif mission_id == 'NI':

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -12,9 +12,8 @@ from osgeo import gdal, osr
 from pyproj import CRS, Proj
 from shapely import geometry
 from compass.utils.h5_helpers import (DATA_PATH,
-                                      METADATA_PATH)
-
-dateformat = '%Y-%m-%d %H:%M:%S.%f'
+                                      METADATA_PATH,
+                                      TIME_STR_FMT)
 
 
 def run(cslc_file, cr_file, csv_output_file=None, plot_age=False,
@@ -208,9 +207,9 @@ def correct_cr_tides(cslc_file, cr_lat, cr_lon,
         stop = h5[stop_path][()]
 
     sensing_start = dt.datetime.strptime(start.decode('UTF-8'),
-                                         dateformat)
+                                         TIME_STR_FMT)
     sensing_stop = dt.datetime.strptime(stop.decode('UTF-8'),
-                                        dateformat)
+                                        TIME_STR_FMT)
 
     # Compute SET in ENU using pySolid
     (_,

--- a/src/compass/utils/age.py
+++ b/src/compass/utils/age.py
@@ -192,8 +192,8 @@ def correct_cr_tides(cslc_file, cr_lat, cr_lon,
     import pysolid
     # Get geocode SLC sensing start and stop
     if mission_id == 'S1':
-        start_path = '/science/SENTINEL1/CSLC/metadata/processing_information/s1_burst_metadata/sensing_start'
-        stop_path = '/science/SENTINEL1/CSLC/metadata/processing_information/s1_burst_metadata/sensing_stop'
+        start_path = '/CSLC/metadata/processing_information/s1_burst_metadata/sensing_start'
+        stop_path = '/CSLC/metadata/processing_information/s1_burst_metadata/sensing_stop'
     elif mission_id == 'NI':
         start_path = '/science/LSAR/GSLC/identification/zeroDopplerStartTime'
         stop_path = '/science/LSAR/GSLC/identification/zeroDopplerEndTime'
@@ -323,7 +323,7 @@ def get_cslc(cslc_file, mission_id='S1', pol='VV'):
     '''
 
     if mission_id == 'S1':
-        cslc_path = f'science/SENTINEL1/CSLC/grids/{pol}'
+        cslc_path = f'CSLC/data/{pol}'
     elif mission_id == 'NI':
         with h5py.File(cslc_file, 'r') as h5:
              frequencies = h5["/science/LSAR/identification/listOfFrequencies"][()]
@@ -368,7 +368,7 @@ def get_xy_info(cslc_file, mission_id='S1', pol='VV'):
         CSLC-S1 spacing along Y-direction
     '''
     if mission_id == 'S1':
-        cslc_path = '/science/SENTINEL1/CSLC/grids/'
+        cslc_path = 'CSLC/data/'
     elif mission_id == 'NI':
         cslc_path = '/science/LSAR/GSLC/grids/frequencyA/'
     else:
@@ -436,7 +436,7 @@ def get_cslc_polygon(cslc_file, mission_id='S1'):
         Shapely polygon including CSLC-S1 valid values
     '''
     if mission_id == 'S1':
-        poly_path = 'science/SENTINEL1/identification/bounding_polygon'
+        poly_path = 'identification/bounding_polygon'
     elif mission_id == 'NI':
         poly_path = 'science/LSAR/identification/boundingPolygon'
     else:
@@ -473,7 +473,7 @@ def get_cslc_epsg(cslc_file, mission_id='S1', pol='VV'):
         geocoded SLC product
     '''
     if mission_id == 'S1':
-        epsg_path = '/science/SENTINEL1/CSLC/grids/projection'
+        epsg_path = 'CSLC/data/projection'
         with h5py.File(cslc_file, 'r') as h5:
             epsg = h5[epsg_path][()]
     elif mission_id == 'NI':

--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -9,7 +9,7 @@ from PIL import Image
 from osgeo import gdal
 
 from compass.utils.geo_runconfig import GeoRunConfig
-from compass.utils.h5_helpers import get_georaster_bounds, GRID_PATH
+from compass.utils.h5_helpers import get_georaster_bounds, DATA_PATH
 
 
 def _scale_to_max_pixel_dimension(orig_shape, max_dim_allowed=2048):
@@ -203,10 +203,10 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
     derived_ds_str = f'DERIVED_SUBDATASET:{complex_to_real.upper()}'
 
     # prepend transform to NETCDF path to grid
-    derived_netcdf_to_grid = f'{derived_ds_str}:NETCDF:{path_h5}:/{GRID_PATH}'
+    derived_netcdf_to_grid = f'{derived_ds_str}:NETCDF:{path_h5}:/{DATA_PATH}'
 
     with h5py.File(path_h5, 'r', swmr=True) as h5_obj:
-        grid_group = h5_obj[GRID_PATH]
+        grid_group = h5_obj[DATA_PATH]
 
         for b in bursts:
             # get polarization to extract geocoded raster

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -566,6 +566,19 @@ def metadata_to_h5group(parent_group, burst, cfg):
     for meta_item in burst_meta_items:
         add_dataset_and_attrs(burst_meta_group, meta_item)
 
+    # Add parameters group in processing information
+    par_meta_items = [
+        Meta('ellipsoidalFlatteningApplied', cfg.geocoding_params.flatten,
+             "If True, CSLC-S1 phase has been flatten with respect to a zero height ellipsoid",
+             {'units':'unitless'}),
+        Meta('topographicFlatteningApplied', cfg.geocoding_params.flatten,
+             "If True, CSLC-S1 phase has been flatten with respect to topographic height using a DEM",
+             {'units': 'unitless'}),
+    ]
+    par_meta_group = processing_group.require_group('parameters')
+    for meta_item in par_meta_items:
+        add_dataset_and_attrs(par_meta_group, meta_item)
+
     def poly1d_to_h5(group, poly1d_name, poly1d):
         '''Write isce3.core.Poly1d properties to hdf5
         Parameters

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -376,7 +376,7 @@ def identity_to_h5group(dst_group, burst, cfg):
              'OGR compatible WKT representation of bounding polygon of the image',
              {'units':'degrees'}),
         Meta('mission_id', burst.platform_id, 'Mission identifier'),
-        Meta('processing_date_time', datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        Meta('processing_date_time', datetime.now().strftime(TIME_STR_FMT),
              'Data processing date and time'),
         Meta('product_type', 'CSLC-S1', 'Product type'),
         Meta('product_level', 'L2', 'L0A: Unprocessed instrument data; L0B: Reformatted, '

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -433,7 +433,6 @@ def metadata_to_h5group(parent_group, burst, cfg):
     if burst.burst_calibration is not None:
         cal = burst.burst_calibration
         cal_items = [
-            Meta('basename', cal.basename_cads, ''),
             Meta('azimuth_time', cal.azimuth_time.strftime(TIME_STR_FMT),
                  'Start time', {'format': 'YYYY-MM-DD HH:MM:SS.6f'}),
             Meta('beta_naught', cal.beta_naught, 'beta_naught')
@@ -446,7 +445,6 @@ def metadata_to_h5group(parent_group, burst, cfg):
     if burst.burst_noise is not None:
         noise = burst.burst_noise
         noise_items = [
-            Meta('basename', noise.basename_nads, ''),
             Meta('range_azimuth_time',
                  noise.range_azimuth_time.strftime(TIME_STR_FMT),
                  'Start time', {'format': 'YYYY-MM-DD HH:MM:SS.6f'})
@@ -467,7 +465,7 @@ def metadata_to_h5group(parent_group, burst, cfg):
              'Input calibration file used'),
         Meta('noise_file', burst.burst_noise.basename_nads,
              'Input noise file used'),
-        Meta('dem_source', os.path.basename(cfg.dem), 'sorce DEM file'),
+        Meta('dem_source', os.path.basename(cfg.dem), 'source DEM file'),
     ]
     input_group = processing_group.require_group('inputs')
     for meta_item in input_items:

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -3,6 +3,7 @@ Collection of functions to help write HDF5 datasets and metadata
 '''
 
 from dataclasses import dataclass, field
+from datetime import datetime
 import os
 
 import isce3
@@ -374,15 +375,23 @@ def identity_to_h5group(dst_group, burst, cfg):
              'OGR compatible WKT representation of bounding polygon of the image',
              {'units':'degrees'}),
         Meta('mission_id', burst.platform_id, 'Mission identifier'),
+        Meta('processing_date_time', datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+             'Data processing date and time'),
         Meta('product_type', 'CSLC-S1', 'Product type'),
+        Meta('product_level', 'L2', 'L0A: Unprocessed instrument data; L0B: Reformatted, '
+             'unprocessed instrument data; L1: Processed instrument data in radar coordinates system; '
+             'and L2: Processed instrument data in geocoded coordinates system'),
         Meta('look_direction', 'Right', 'Look direction can be left or right'),
+        Meta('instrument_name', 'C-SAR', 'Instrument name'),
         Meta('orbit_pass_direction', burst.orbit_direction,
              'Orbit direction can be ascending or descending'),
+        Meta('radar_band', 'C', 'Radar band'),
         Meta('zero_doppler_start_time', burst.sensing_start.strftime(TIME_STR_FMT),
              'Azimuth start time of product'),
         Meta('zero_doppler_end_time', burst.sensing_stop.strftime(TIME_STR_FMT),
             'Azimuth stop time of product'),
         Meta('is_geocoded', 'True', 'Boolean indicating if product is in radar geometry or geocoded'),
+        Meta('processing_center', 'Jet Propulsion Laboratory', 'Name of the processing center that produced the product')
         ]
     id_group = dst_group.require_group('identification')
     for meta_item in id_meta_items:

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -17,9 +17,10 @@ import compass
 
 
 TIME_STR_FMT = '%Y-%m-%d %H:%M:%S.%f'
-ROOT_PATH = 'CSLC'
-DATA_PATH = f'{ROOT_PATH}/data'
-QA_PATH = f'{ROOT_PATH}/quality_assurance'
+ROOT_PATH = '/'
+DATA_PATH = '/data'
+QA_PATH = '/quality_assurance'
+METADATA_PATH = '/metadata'
 
 
 @dataclass
@@ -629,7 +630,7 @@ def corrections_to_h5group(parent_group, burst, cfg, rg_lut, az_lut,
     # Open GDAL dataset to fetch corrections
     ds = gdal.Open(f'{scratch_path}/corrections/corrections',
                    gdal.GA_ReadOnly)
-    correction_group = parent_group.require_group('corrections')
+    correction_group = parent_group.require_group('timing_corrections')
 
     # create slant range and azimuth vectors shared by the LUTs
     x_end = rg_lut.x_start + rg_lut.width * rg_lut.x_spacing

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -18,7 +18,7 @@ import compass
 
 TIME_STR_FMT = '%Y-%m-%d %H:%M:%S.%f'
 ROOT_PATH = 'CSLC'
-GRID_PATH = f'{ROOT_PATH}/data'
+DATA_PATH = f'{ROOT_PATH}/data'
 QA_PATH = f'{ROOT_PATH}/quality_assurance'
 
 
@@ -749,7 +749,7 @@ def get_cslc_geotransform(filename: str, pol: str = "VV"):
     list
         Geotransform of the geocoded raster
     '''
-    gdal_str = f'NETCDF:{filename}:/{GRID_PATH}/{pol}'
+    gdal_str = f'NETCDF:{filename}:/{DATA_PATH}/{pol}'
     return gdal.Info(gdal_str, format='json')['geoTransform']
 
 
@@ -770,7 +770,7 @@ def get_georaster_bounds(filename: str, pol: str = 'VV'):
         WGS84 coordinates of the geocoded raster boundary given as min_x,
         max_x, min_y, max_y
     '''
-    nfo = gdal.Info(f'NETCDF:{filename}:/{GRID_PATH}/{pol}', format='json')
+    nfo = gdal.Info(f'NETCDF:{filename}:/{DATA_PATH}/{pol}', format='json')
 
     # set extreme initial values for min/max x/y
     min_x = 999999

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -17,8 +17,8 @@ import compass
 
 
 TIME_STR_FMT = '%Y-%m-%d %H:%M:%S.%f'
-ROOT_PATH = '/science/SENTINEL1/CSLC'
-GRID_PATH = f'{ROOT_PATH}/grids'
+ROOT_PATH = 'CSLC'
+GRID_PATH = f'{ROOT_PATH}/data'
 QA_PATH = f'{ROOT_PATH}/quality_assurance'
 
 

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -485,7 +485,7 @@ def metadata_to_h5group(parent_group, burst, cfg):
         Meta('last_valid_line', burst.last_valid_line,
              'Last valid line for burst in measurement tiff')
     ]
-    vrt_group = input_group.require_group('vrt_parameters')
+    vrt_group = input_group.require_group('burst_location_parameters')
     for meta_item in vrt_items:
         add_dataset_and_attrs(vrt_group, meta_item)
 
@@ -562,7 +562,7 @@ def metadata_to_h5group(parent_group, burst, cfg):
         Meta('range_chirp_rate', burst.range_chirp_rate,
              'Range chirp rate', {'units':'Hz'})
     ]
-    burst_meta_group = processing_group.require_group('s1_burst_metadata')
+    burst_meta_group = processing_group.require_group('input_burst_metadata')
     for meta_item in burst_meta_items:
         add_dataset_and_attrs(burst_meta_group, meta_item)
 

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -10,7 +10,7 @@ import numpy as np
 from osgeo import gdal
 
 
-DATA_ROOT = 'science/SENTINEL1'
+DATA_ROOT = 'CSLC'
 
 
 def cmd_line_parser():
@@ -55,7 +55,7 @@ def _grid_info_retrieve(path_h5, dataset_names, is_static_layer):
     proj: str
         Map projection of the raster in WKT
     """
-    grid_path = f'{DATA_ROOT}/CSLC/grids'
+    grid_path = f'{DATA_ROOT}/data'
     if is_static_layer:
         grid_path += '/static_layers'
 
@@ -158,7 +158,7 @@ def _compare_static_layer_rasters(file_ref, file_sec, static_layer_items):
     static_layer_items: list[str]
         List of names of static layers to compare
     """
-    grid_path = f'{DATA_ROOT}/CSLC/grids/static_layers'
+    grid_path = f'{DATA_ROOT}/data/static_layers'
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
         for static_layer_item in static_layer_items:
             if static_layer_item == 'layover_shadow_mask':
@@ -210,7 +210,7 @@ def _compare_complex_slc_rasters(file_ref, file_sec, pols):
     pols: list[str]
         List of polarizations of rasters to compare
     """
-    grid_path = f'{DATA_ROOT}/CSLC/grids'
+    grid_path = f'{DATA_ROOT}/data'
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
         for pol in pols:
             # Retrieve SLC raster from ref and sec HDF5

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -9,6 +9,8 @@ import h5py
 import numpy as np
 from osgeo import gdal
 
+from compass.utils.h5_helpers import DATA_PATH
+
 
 DATA_ROOT = 'CSLC'
 
@@ -55,19 +57,19 @@ def _grid_info_retrieve(path_h5, dataset_names, is_static_layer):
     proj: str
         Map projection of the raster in WKT
     """
-    grid_path = f'{DATA_ROOT}/data'
+    data_path = DATA_PATH
     if is_static_layer:
-        grid_path += '/static_layers'
+        data_path += '/static_layers'
 
     # Extract existing dataset names with h5py
     with h5py.File(path_h5) as h:
         datasets_found = [ds_name for ds_name in dataset_names
-                if ds_name in h[grid_path]]
+                if ds_name in h[data_path]]
 
     ds_name = datasets_found[0]
 
     # Extract some info from reference/secondary products with GDAL
-    h5_gdal_path = f'NETCDF:{path_h5}://{grid_path}/{ds_name}'
+    h5_gdal_path = f'NETCDF:{path_h5}://{data_path}/{ds_name}'
     dataset = gdal.Open(h5_gdal_path, gdal.GA_ReadOnly)
     geotransform = dataset.GetGeoTransform()
     proj = dataset.GetProjection()
@@ -158,15 +160,15 @@ def _compare_static_layer_rasters(file_ref, file_sec, static_layer_items):
     static_layer_items: list[str]
         List of names of static layers to compare
     """
-    grid_path = f'{DATA_ROOT}/data/static_layers'
+    data_path = f'{DATA_PATH}/static_layers'
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
         for static_layer_item in static_layer_items:
             if static_layer_item == 'layover_shadow_mask':
                 continue
 
             # Retrieve static layer raster from ref and sec HDF5
-            slc_ref = h_ref[f'{grid_path}/{static_layer_item}']
-            slc_sec = h_sec[f'{grid_path}/{static_layer_item}']
+            slc_ref = h_ref[f'{data_path}/{static_layer_item}']
+            slc_sec = h_sec[f'{data_path}/{static_layer_item}']
 
             # Compute total number of pixels different from nan from ref and sec
             ref_nan = np.isnan(slc_ref)
@@ -210,12 +212,12 @@ def _compare_complex_slc_rasters(file_ref, file_sec, pols):
     pols: list[str]
         List of polarizations of rasters to compare
     """
-    grid_path = f'{DATA_ROOT}/data'
+    data_path = DATA_PATH
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
         for pol in pols:
             # Retrieve SLC raster from ref and sec HDF5
-            slc_ref = h_ref[f'{grid_path}/{pol}']
-            slc_sec = h_sec[f'{grid_path}/{pol}']
+            slc_ref = h_ref[f'{data_path}/{pol}']
+            slc_sec = h_sec[f'{data_path}/{pol}']
 
             # Compute total number of pixels different from nan from ref and sec
             ref_nan = np.isnan(slc_ref)

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -164,8 +164,9 @@ def _compare_static_layer_rasters(file_ref, file_sec, static_layer_items):
                 continue
 
             # Retrieve static layer raster from ref and sec HDF5
-            slc_ref = h_ref[f'{data_path}/{static_layer_item}']
-            slc_sec = h_sec[f'{data_path}/{static_layer_item}']
+            static_path = f'{data_path}/{static_layer_item}'
+            slc_ref = h_ref[static_path]
+            slc_sec = h_sec[static_path]
 
             # Compute total number of pixels different from nan from ref and sec
             ref_nan = np.isnan(slc_ref)
@@ -209,12 +210,11 @@ def _compare_complex_slc_rasters(file_ref, file_sec, pols):
     pols: list[str]
         List of polarizations of rasters to compare
     """
-    data_path = DATA_PATH
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
         for pol in pols:
             # Retrieve SLC raster from ref and sec HDF5
-            slc_ref = h_ref[f'{data_path}/{pol}']
-            slc_sec = h_sec[f'{data_path}/{pol}']
+            slc_ref = h_ref[f'{DATA_PATH}/{pol}']
+            slc_sec = h_sec[f'{DATA_PATH}/{pol}']
 
             # Compute total number of pixels different from nan from ref and sec
             ref_nan = np.isnan(slc_ref)

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -59,7 +59,7 @@ def _grid_info_retrieve(path_h5, dataset_names, is_static_layer):
         data_path += '/static_layers'
 
     # Extract existing dataset names with h5py
-    with h5py.File(path_h5) as h:
+    with h5py.File(path_h5, 'r') as h:
         datasets_found = [ds_name for ds_name in dataset_names
                 if ds_name in h[data_path]]
 

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -9,10 +9,7 @@ import h5py
 import numpy as np
 from osgeo import gdal
 
-from compass.utils.h5_helpers import DATA_PATH
-
-
-DATA_ROOT = 'CSLC'
+from compass.utils.h5_helpers import DATA_PATH, ROOT_PATH
 
 
 def cmd_line_parser():
@@ -300,8 +297,8 @@ def compare_cslc_metadata(file_ref, file_sec):
 
     # Get metadata keys
     with h5py.File(file_ref, 'r') as h_ref, h5py.File(file_sec, 'r') as h_sec:
-        metadata_ref = set(_get_group_item_paths(h_ref[DATA_ROOT]))
-        metadata_sec = set(_get_group_item_paths(h_sec[DATA_ROOT]))
+        metadata_ref = set(_get_group_item_paths(h_ref[ROOT_PATH]))
+        metadata_sec = set(_get_group_item_paths(h_sec[ROOT_PATH]))
 
     # Intersect metadata keys
     set_ref_minus_sec = metadata_ref - metadata_sec

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import requests
 from s1reader.s1_orbit import check_internet_connection
 
 from compass.utils import iono
+from compass.utils.h5_helpers import DATA_PATH
 
 
 def download_if_needed(local_path):
@@ -92,7 +93,7 @@ def geocode_slc_params():
     test_params.output_hdf5_path = f'{output_path}/{output_file_name}'
 
     # path to groups and datasets in output HDF5
-    test_params.grid_group_path = '/data'
+    test_params.grid_group_path = DATA_PATH
     test_params.raster_path = f'{test_params.grid_group_path}/VV'
 
     return test_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def geocode_slc_params():
     test_params.output_hdf5_path = f'{output_path}/{output_file_name}'
 
     # path to groups and datasets in output HDF5
-    test_params.grid_group_path = '/CSLC/grids'
+    test_params.grid_group_path = '/CSLC/data'
     test_params.raster_path = f'{test_params.grid_group_path}/VV'
 
     return test_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def geocode_slc_params():
     test_params.output_hdf5_path = f'{output_path}/{output_file_name}'
 
     # path to groups and datasets in output HDF5
-    test_params.grid_group_path = '/science/SENTINEL1/CSLC/grids'
+    test_params.grid_group_path = '/CSLC/grids'
     test_params.raster_path = f'{test_params.grid_group_path}/VV'
 
     return test_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def geocode_slc_params():
     test_params.output_hdf5_path = f'{output_path}/{output_file_name}'
 
     # path to groups and datasets in output HDF5
-    test_params.grid_group_path = '/CSLC/data'
+    test_params.grid_group_path = '/data'
     test_params.raster_path = f'{test_params.grid_group_path}/VV'
 
     return test_params


### PR DESCRIPTION
This PR removes the path "s/science/SENTINEL1" to both the CSLC-S1 and the static layers product. 
In addition, the PR adds new metadata entries to the identification group.

The PR has been tested by generating the CSLC product and the static layers for one burst only.