### PR TITLE
Change product version and spec version to strings

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -35,9 +35,9 @@ runconfig:
           # PGE may rename the product according to file naming convention
           sas_output_file:
           # Product version
-          product_version: 0.2
+          product_version: '0.2'
           # Product specification document version
-          product_specification_version: 0.1.5
+          product_specification_version: '0.1.5'
 
       primary_executable:
           product_type: CSLC_S1

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -35,9 +35,9 @@ runconfig:
            # PGE may rename the product according to file naming convention
            sas_output_file: str()
            # Product version
-           product_version: num(required=False)
+           product_version: str(required=False)
            # Product specification document version
-           product_specification_version: num(required=False)
+           product_specification_version: str(required=False)
 
         primary_executable:
           product_type: enum('CSLC_S1')


### PR DESCRIPTION
This PR changes the following entry of the schema

- product_version
- product_specification_version

to be strings instead of numbers. In this way, we can support versioning with the following format e..g., 0.1.5