### PR TITLE
Browse image on antimeridian

### DIFF
--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -224,6 +224,8 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
             # Check if the raster crosses antimeridian
             if max_x - min_x > 180.0:
                 gdal.SetConfigOption('CENTER_LONG', '180')
+                min_x += 360.0
+                min_x, max_x = max_x, min_x
             else:
                 gdal.SetConfigOption('CENTER_LONG', None)
 
@@ -231,9 +233,9 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
             ds_wgs84 = gdal.Warp('', src_raster, format='MEM',
                                  dstSRS='EPSG:4326',
                                  width=browse_w, height=browse_h,
-                                 resampleAlg = gdal.GRIORA_Bilinear,
-                                 outputBounds=(min_x, min_y, max_x, max_y),
-                                 )
+                                 resampleAlg=gdal.GRIORA_Bilinear,
+                                 outputBounds=(min_x, min_y, max_x, max_y)
+                                )
             image = ds_wgs84.ReadAsArray()
 
             # get hi/lo values by percentile

--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -234,6 +234,7 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
                                  dstSRS='EPSG:4326',
                                  width=browse_w, height=browse_h,
                                  resampleAlg=gdal.GRIORA_Bilinear,
+                                 dstNodata = float('nan'),
                                  outputBounds=(min_x, min_y, max_x, max_y)
                                 )
             image = ds_wgs84.ReadAsArray()

--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -224,8 +224,8 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
             # Check if the raster crosses antimeridian
             if max_x - min_x > 180.0:
                 gdal.SetConfigOption('CENTER_LONG', '180')
-                min_x += 360.0
-                min_x, max_x = max_x, min_x
+                # Adjust the min / max in the X direction (longitude)
+                min_x, max_x = max_x, min_x + 360.0
             else:
                 gdal.SetConfigOption('CENTER_LONG', None)
 

--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -221,6 +221,12 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
 
             min_x, max_x, min_y, max_y = get_georaster_bounds(path_h5, pol)
 
+            # Check if the raster crosses antimeridian
+            if max_x - min_x > 180.0:
+                gdal.SetConfigOption('CENTER_LONG', '180')
+            else:
+                gdal.SetConfigOption('CENTER_LONG', None)
+
             # gdal warp to right geo extents, image shape and EPSG
             ds_wgs84 = gdal.Warp('', src_raster, format='MEM',
                                  dstSRS='EPSG:4326',

--- a/src/compass/utils/browse_image.py
+++ b/src/compass/utils/browse_image.py
@@ -234,7 +234,7 @@ def make_browse_image(filename, path_h5, bursts, complex_to_real='amplitude', pe
                                  dstSRS='EPSG:4326',
                                  width=browse_w, height=browse_h,
                                  resampleAlg=gdal.GRIORA_Bilinear,
-                                 dstNodata = float('nan'),
+                                 dstNodata=float('nan'),
                                  outputBounds=(min_x, min_y, max_x, max_y)
                                 )
             image = ds_wgs84.ReadAsArray()


### PR DESCRIPTION
This PR address issues when generating the browse image of the burst CSLC that crosses antimeridian.

Below are the details about the test data
SAFE file name : S1B_IW_SLC__1SDV_20210411T184626_20210411T184656_026423_032787_7662.zip
Orbit file name: S1B_OPER_AUX_POEORB_OPOD_20210501T111617_V20210410T225942_20210412T005942.EOF
Burst ID: t147_314253_iw1

<img width="2118" alt="Screenshot 2023-05-09 at 09 45 43" src="https://github.com/opera-adt/COMPASS/assets/27862199/08a5afed-6d64-4824-96db-fb2ec281431e">
Figure 1. Amplitude of CSLC in its original map projection (EPSG:32660)

![t147_314253_iw1_20210411](https://github.com/opera-adt/COMPASS/assets/27862199/f7dbb03e-722e-433b-b7f7-ff99cf4c6220)
Figure 2. Browse image in geographic coordinates (EPSG:4326)


NOTE: Currently this PR is labeled as `WIP`, which will be removed once the black margins around the browse images are removed.