### PR TITLE
Force `s1_rdr2geo` to correctly run in `s1_geocode_slc` for static layer generation

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -86,7 +86,7 @@ runconfig:
               # Enable/disable computation of longitude raster
               compute_longitude: False
               # Enable/disable computation of height raster
-              compute_height: True
+              compute_height: False
               # Enable/disable layover shadow mask output
               compute_layover_shadow_mask: True
               # Enable/disable incidence angle output

--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -82,9 +82,9 @@ runconfig:
               # Secondary number of iterations
               extraiter: 10
               # Enable/disable computation of latitude raster
-              compute_latitude: True
+              compute_latitude: False
               # Enable/disable computation of longitude raster
-              compute_longitude: True
+              compute_longitude: False
               # Enable/disable computation of height raster
               compute_height: True
               # Enable/disable layover shadow mask output

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -147,9 +147,10 @@ def run(cfg, burst, fetch_from_scratch=False):
     with h5py.File(out_h5, 'w') as h5_root:
         # write identity and metadata to HDF5
         root_group = h5_root[ROOT_PATH]
+        metadata_to_h5group(root_group, burst, cfg, save_noise_and_cal=False,
+                            save_processing_parameters=False)
         identity_to_h5group(root_group, burst, cfg, 'Static layers CSLC-S1',
                             '0.1')
-        metadata_to_h5group(root_group, burst, cfg, save_noise_and_cal=False)
         algorithm_metadata_to_h5group(root_group, is_static_layers=True)
 
         # Create group static_layers group under DATA_PATH for consistency with

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -137,7 +137,10 @@ def run(cfg: GeoRunConfig):
 
         # Generate required static layers
         if cfg.rdr2geo_params.enabled:
-            rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
+            if cfg.rdr2geo_params.compute_layover_shadow_mask:
+                rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
+            else:
+                rdr2geo_cfg = cfg
             s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
             if cfg.rdr2geo_params.geocode_metadata_layers:
                 s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -138,7 +138,7 @@ def run(cfg: GeoRunConfig):
         # Generate required static layers
         if cfg.rdr2geo_params.enabled:
             rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
-            #s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
+            s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
             if cfg.rdr2geo_params.geocode_metadata_layers:
                 s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
 

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -137,10 +137,7 @@ def run(cfg: GeoRunConfig):
 
         # Generate required static layers
         if cfg.rdr2geo_params.enabled:
-            if cfg.rdr2geo_params.compute_layover_shadow_mask:
-                rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
-            else:
-                rdr2geo_cfg = cfg
+            rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
             s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
             if cfg.rdr2geo_params.geocode_metadata_layers:
                 s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)

--- a/src/compass/utils/geo_runconfig.py
+++ b/src/compass/utils/geo_runconfig.py
@@ -43,37 +43,6 @@ def check_geocode_dict(geocode_cfg: dict) -> None:
                 raise ValueError(err_str)
 
 
-def check_rdr2geo_dict(rdr2geo_dict: dict) -> None:
-    error_channel = journal.error('runconfig.check_rdr2geo_dict')
-
-    # skip further checks if not geocoding static layers or layover shadow not
-    # computed
-    if not rdr2geo_dict['geocode_metadata_layers'] or \
-            not rdr2geo_dict['compute_layover_shadow_mask']:
-        return
-
-    # layover shadow requires latitude/y, longitude/x, and incidence angle
-    # check if all three exist
-    # this also ensures that a CPU geocoded raster with correctly set invalid
-    # values exists, so it can used to mask geocoded layer shadow raster since
-    # CPU isce3.geocode.geocode can not set a user defined invalid value
-    # layover shadow invalid needs to be 127 but CPU isce3.geocode.geocode
-    # sets it to 0 (which conflicts with the non layover, non shadow value)
-    layers_for_layer_shadow = {
-        layer: rdr2geo_dict[f'compute_{layer}']
-        for layer in ['latitude', 'longitude', 'incidence_angle']}
-
-    # raise error if required layers do not exist
-    if not all(layers_for_layer_shadow.values()):
-        # get names of missing layers for error string
-        missing_layers = ', '.join([k
-                                    for k, v in layers_for_layer_shadow.items()
-                                    if not v])
-        err_str = f'Can not generate layover shadow. Missing: {missing_layers}'
-        error_channel.log(err_str)
-        raise ValueError(err_str)
-
-
 @dataclass(frozen=True)
 class GeoRunConfig(RunConfig):
     '''dataclass containing GSLC runconfig'''
@@ -104,9 +73,6 @@ class GeoRunConfig(RunConfig):
 
         geocoding_dict = groups_cfg['processing']['geocoding']
         check_geocode_dict(geocoding_dict)
-
-        rdr2geo_dict = groups_cfg['processing']['rdr2geo']
-        check_rdr2geo_dict(rdr2geo_dict)
 
         # Check TEC file if not None.
         # The ionosphere correction will be applied only if

--- a/src/compass/utils/geo_runconfig.py
+++ b/src/compass/utils/geo_runconfig.py
@@ -50,19 +50,20 @@ class GeoRunConfig(RunConfig):
     geogrids: dict[str, GeoGridParameters]
 
     @classmethod
-    def load_from_yaml(cls, yaml_path: str, workflow_name: str) -> GeoRunConfig:
+    def load_from_yaml(cls, yaml_runconfig: str, workflow_name: str) -> GeoRunConfig:
         """Initialize RunConfig class with options from given yaml file.
 
         Parameters
         ----------
-        yaml_path : str
-            Path to yaml file containing the options to load
+        yaml_runconfig : str
+            Path to yaml file containing the options to load or string contents
+            of a runconfig
         workflow_name: str
             Name of the workflow for which uploading default options
         """
         error_channel = journal.error('runconfig.load_from_yaml')
 
-        cfg = load_validate_yaml(yaml_path, workflow_name)
+        cfg = load_validate_yaml(yaml_runconfig, workflow_name)
         groups_cfg = cfg['runconfig']['groups']
 
         burst_database_file = groups_cfg['static_ancillary_file_group']['burst_database_file']

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -564,11 +564,13 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
 
     # Add parameters group in processing information
     if save_processing_parameters:
-        dry_tropo_corr = True if (cfg.weather_model_file is not None) and \
-                                 ('dry' in cfg.tropo_params.delay_type) else False
-        wet_tropo_corr = True if (cfg.weather_model_file is not None) and \
-                                 ('wet' in cfg.tropo_params.delay_type) else False
-        tec_corr = True if cfg.tec_file is not None else False
+        dry_tropo_corr_enabled = \
+            True if (cfg.weather_model_file is not None) and \
+            ('dry' in cfg.tropo_params.delay_type) else False
+        wet_tropo_corr_enabled = \
+            True if (cfg.weather_model_file is not None) and \
+            ('wet' in cfg.tropo_params.delay_type) else False
+        tec_corr_enabled = True if cfg.tec_file is not None else False
         par_meta_items = [
             Meta('ellipsoidal_flattening_applied',
                  bool(cfg.geocoding_params.flatten),
@@ -592,11 +594,13 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
             Meta('static_troposphere_applied',
                  bool(cfg.lut_params.enabled),
                  "If True, troposphere correction based on a static model has been applied"),
-            Meta('ionosphere_tec_applied', tec_corr,
+            Meta('ionosphere_tec_applied', tec_corr_enabled,
                  "If True, ionosphere correction based on TEC data has been applied"),
-            Meta('dry_troposphere_weather_model_applied', dry_tropo_corr,
+            Meta('dry_troposphere_weather_model_applied',
+                 dry_tropo_corr_enabled,
                  "If True, dry troposphere correction based on weather model has been applied"),
-            Meta('wet_troposphere_weather_model_applied', wet_tropo_corr,
+            Meta('wet_troposphere_weather_model_applied',
+                 wet_tropo_corr_enabled,
                  "If True, wet troposphere correction based on weather model has been applied")
         ]
         par_meta_group = processing_group.require_group('parameters')

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -681,7 +681,7 @@ def algorithm_metadata_to_h5group(parent_group, is_static_layers=False):
                  'Complex data geocoding interpolation method'),
         )
     algorithm_group = \
-        parent_group.require_group('metadata/processing_information/algorithm')
+        parent_group.require_group('metadata/processing_information/algorithms')
     for meta_item in algorithm_items:
         add_dataset_and_attrs(algorithm_group, meta_item)
 

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -408,7 +408,8 @@ def identity_to_h5group(dst_group, burst, cfg, product_type,
         add_dataset_and_attrs(id_group, meta_item)
 
 
-def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True):
+def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
+                        save_processing_parameters=True):
     '''
     Write burst metadata to HDF5
 
@@ -422,6 +423,8 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True):
         SimpleNamespace containing run configuration
     save_noise_and_cal: bool
         If true, to save noise and calibration metadata in metadata
+    save_processing_parameters: bool
+        If true, to save processing parameters in metadata
     '''
     if 'metadata' in parent_group:
         del parent_group['metadata']
@@ -560,38 +563,45 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True):
         add_dataset_and_attrs(burst_meta_group, meta_item)
 
     # Add parameters group in processing information
-    dry_tropo_corr = True if (cfg.weather_model_file is not None) and \
-                             ('dry' in cfg.tropo_params.delay_type) else False
-    wet_tropo_corr = True if (cfg.weather_model_file is not None) and \
-                             ('wet' in cfg.tropo_params.delay_type) else False
-    tec_corr = True if cfg.tec_file is not None else False
-    par_meta_items = [
-        Meta('ellipsoidal_flattening_applied', bool(cfg.geocoding_params.flatten),
-             "If True, CSLC-S1 phase has been flattened with respect to a zero height ellipsoid"),
-        Meta('topographic_flattening_applied', bool(cfg.geocoding_params.flatten),
-             "If True, CSLC-S1 phase has been flattened with respect to topographic height using a DEM"),
-        Meta('bistatic_delay_applied', bool(cfg.lut_params.enabled),
-             "If True, bistatic delay timing correction has been applied"),
-        Meta('azimuth_fm_rate_applied', bool(cfg.lut_params.enabled),
-             "If True, azimuth FM-rate mismatch timing correction has been applied"),
-        Meta('geometry_doppler_applied', bool(cfg.lut_params.enabled),
-             "If True, geometry steering doppler timing correction has been applied"),
-        Meta('los_solid_earth_tides_applied', bool(cfg.lut_params.enabled),
-             "If True, solid Earth tides correction has been applied in slant range direction"),
-        Meta('azimuth_solid_earth_tides_applied', False,
-             "If True, solid Earth tides correction has been applied in azimuth direction"),
-        Meta('static_troposphere_applied', bool(cfg.lut_params.enabled),
-             "If True, troposphere correction based on a static model has been applied"),
-        Meta('ionosphere_tec_applied', tec_corr,
-             "If True, ionosphere correction based on TEC data has been applied"),
-        Meta('dry_troposphere_weather_model_applied', dry_tropo_corr,
-             "If True, dry troposphere correction based on weather model has been applied"),
-        Meta('wet_troposphere_weather_model_applied', wet_tropo_corr,
-             "If True, wet troposphere correction based on weather model has been applied")
-    ]
-    par_meta_group = processing_group.require_group('parameters')
-    for meta_item in par_meta_items:
-        add_dataset_and_attrs(par_meta_group, meta_item)
+    if save_processing_parameters:
+        dry_tropo_corr = True if (cfg.weather_model_file is not None) and \
+                                 ('dry' in cfg.tropo_params.delay_type) else False
+        wet_tropo_corr = True if (cfg.weather_model_file is not None) and \
+                                 ('wet' in cfg.tropo_params.delay_type) else False
+        tec_corr = True if cfg.tec_file is not None else False
+        par_meta_items = [
+            Meta('ellipsoidal_flattening_applied',
+                 bool(cfg.geocoding_params.flatten),
+                 "If True, CSLC-S1 phase has been flattened with respect to a zero height ellipsoid"),
+            Meta('topographic_flattening_applied',
+                 bool(cfg.geocoding_params.flatten),
+                 "If True, CSLC-S1 phase has been flattened with respect to topographic height using a DEM"),
+            Meta('bistatic_delay_applied',
+                 bool(cfg.lut_params.enabled),
+                 "If True, bistatic delay timing correction has been applied"),
+            Meta('azimuth_fm_rate_applied',
+                 bool(cfg.lut_params.enabled),
+                 "If True, azimuth FM-rate mismatch timing correction has been applied"),
+            Meta('geometry_doppler_applied',
+                 bool(cfg.lut_params.enabled),
+                 "If True, geometry steering doppler timing correction has been applied"),
+            Meta('los_solid_earth_tides_applied', bool(cfg.lut_params.enabled),
+                 "If True, solid Earth tides correction has been applied in slant range direction"),
+            Meta('azimuth_solid_earth_tides_applied', False,
+                 "If True, solid Earth tides correction has been applied in azimuth direction"),
+            Meta('static_troposphere_applied',
+                 bool(cfg.lut_params.enabled),
+                 "If True, troposphere correction based on a static model has been applied"),
+            Meta('ionosphere_tec_applied', tec_corr,
+                 "If True, ionosphere correction based on TEC data has been applied"),
+            Meta('dry_troposphere_weather_model_applied', dry_tropo_corr,
+                 "If True, dry troposphere correction based on weather model has been applied"),
+            Meta('wet_troposphere_weather_model_applied', wet_tropo_corr,
+                 "If True, wet troposphere correction based on weather model has been applied")
+        ]
+        par_meta_group = processing_group.require_group('parameters')
+        for meta_item in par_meta_items:
+            add_dataset_and_attrs(par_meta_group, meta_item)
 
     def poly1d_to_h5(group, poly1d_name, poly1d):
         '''Write isce3.core.Poly1d properties to hdf5

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -49,11 +49,8 @@ def load_validate_yaml(yaml_runconfig: str, workflow_name: str) -> dict:
         error_channel.log(err_str)
         raise ValueError(err_str)
 
-    # set run config type
-    run_config_is_txt = False
-    # if newlines then run_config is YAML string
-    if '\n' in yaml_runconfig:
-        run_config_is_txt = True
+    # Determine run config type based on existence of newlines
+    run_config_is_txt = '\n' in yaml_runconfig:
 
     if not run_config_is_txt and not os.path.isfile(yaml_runconfig):
         raise FileNotFoundError(f'Yaml file {yaml_runconfig} not found.')

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -57,7 +57,7 @@ def load_validate_yaml(yaml_runconfig: str, workflow_name: str) -> dict:
 
     # load yaml file or string from command line
     try:
-        if run_config_is_txt:
+        if run_config_is_txt
             data = yamale.make_data(content=yaml_runconfig,
                                     parser='ruamel')
         else:

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -50,14 +50,14 @@ def load_validate_yaml(yaml_runconfig: str, workflow_name: str) -> dict:
         raise ValueError(err_str)
 
     # Determine run config type based on existence of newlines
-    run_config_is_txt = '\n' in yaml_runconfig:
+    run_config_is_txt = '\n' in yaml_runconfig
 
     if not run_config_is_txt and not os.path.isfile(yaml_runconfig):
         raise FileNotFoundError(f'Yaml file {yaml_runconfig} not found.')
 
     # load yaml file or string from command line
     try:
-        if run_config_is_txt
+        if run_config_is_txt:
             data = yamale.make_data(content=yaml_runconfig,
                                     parser='ruamel')
         else:

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -19,13 +19,14 @@ from compass.utils.radar_grid import file_to_rdr_grid
 from compass.utils.wrap_namespace import wrap_namespace, unwrap_to_dict
 
 
-def load_validate_yaml(yaml_path: str, workflow_name: str) -> dict:
+def load_validate_yaml(yaml_runconfig: str, workflow_name: str) -> dict:
     """Initialize RunConfig class with options from given yaml file.
 
     Parameters
     ----------
-    yaml_path : str
-        Path to yaml file containing the options to load
+    yaml_runconfig : str
+        Path to yaml file containing the options to load or string contents of
+        a runconfig
     workflow_name: str
         Name of the workflow for which uploading default options
 
@@ -48,22 +49,32 @@ def load_validate_yaml(yaml_path: str, workflow_name: str) -> dict:
         error_channel.log(err_str)
         raise ValueError(err_str)
 
+    # set run config type
+    run_config_is_txt = False
+    # if newlines then run_config is YAML string
+    if '\n' in yaml_runconfig:
+        run_config_is_txt = True
+
+    if not run_config_is_txt and not os.path.isfile(yaml_runconfig):
+        raise FileNotFoundError(f'Yaml file {yaml_runconfig} not found.')
+
     # load yaml file or string from command line
-    if os.path.isfile(yaml_path):
-        try:
-            data = yamale.make_data(yaml_path, parser='ruamel')
-        except yamale.YamaleError as yamale_err:
-            err_str = f'Yamale unable to load {workflow_name} runconfig yaml {yaml_path} for validation.'
-            error_channel.log(err_str)
-            raise yamale.YamaleError(err_str) from yamale_err
-    else:
-        raise FileNotFoundError(f'Yaml file {yaml_path} not found.')
+    try:
+        if run_config_is_txt:
+            data = yamale.make_data(content=yaml_runconfig,
+                                    parser='ruamel')
+        else:
+            data = yamale.make_data(yaml_runconfig, parser='ruamel')
+    except yamale.YamaleError as yamale_err:
+        err_str = f'Yamale unable to load {workflow_name} runconfig yaml {yaml_runconfig} for validation.'
+        error_channel.log(err_str)
+        raise yamale.YamaleError(err_str) from yamale_err
 
     # validate yaml file taken from command line
     try:
         yamale.validate(schema, data)
     except yamale.YamaleError as yamale_err:
-        err_str = f'Validation fail for {workflow_name} runconfig yaml {yaml_path}.'
+        err_str = f'Validation fail for {workflow_name} runconfig yaml {yaml_runconfig}.'
         error_channel.log(err_str)
         raise yamale.YamaleError(err_str) from yamale_err
 
@@ -73,8 +84,12 @@ def load_validate_yaml(yaml_path: str, workflow_name: str) -> dict:
     with open(default_cfg_path, 'r') as f_default:
         default_cfg = parser.load(f_default)
 
-    with open(yaml_path, 'r') as f_yaml:
-        user_cfg = parser.load(f_yaml)
+    # load user config based on input type
+    if run_config_is_txt:
+        user_cfg = parser.load(yaml_runconfig)
+    else:
+        with open(yaml_runconfig, 'r') as f_yaml:
+            user_cfg = parser.load(f_yaml)
 
     # Copy user-supplied configuration options into default runconfig
     helpers.deep_update(default_cfg, user_cfg)


### PR DESCRIPTION
This PR:
1. forces `s1_rdr2geo` inside `s1_geocode_slc` to generate layers needed for layover shadow computation by creating a new runconfig with the correct flags enabled
2. allow runconfigs to be loaded by yaml string
3. removes unnecessary rdr2geo runconfig check
4. updates defaults so x and y layers are off by default