### PR TITLE
bug fixes in `gdal.Open` and `validate_product.py`

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -95,15 +95,17 @@ def run(cfg: GeoRunConfig):
     for burst_id, bursts in bursts_grouping_generator(cfg.bursts):
         burst = bursts[0]
 
+        date_str = burst.sensing_start.strftime("%Y%m%d")
+        geo_grid = cfg.geogrids[burst_id]
+
+        info_channel.log(f'Starting geocoding of {burst_id} for {date_str}')
+
         # Reinitialize the dem raster per burst to prevent raster artifacts
         # caused by modification in geocodeSlc
         dem_raster = isce3.io.Raster(cfg.dem)
         epsg = dem_raster.get_epsg()
         proj = isce3.core.make_projection(epsg)
         ellipsoid = proj.ellipsoid
-
-        date_str = burst.sensing_start.strftime("%Y%m%d")
-        geo_grid = cfg.geogrids[burst_id]
 
         # Get output paths for current burst
         burst_id_date_key = (burst_id, date_str)

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -342,6 +342,7 @@ def open_raster(filename, band=1):
         ds = gdal.Open(filename, gdal.GA_ReadOnly)
         raster = ds.GetRasterBand(band).ReadAsArray()
     except ValueError:
+        error_channel = journal.error('helpers.check_dem')
         err_str = f'{filename} cannot be opened by GDAL'
         error_channel.log(err_str)
         raise ValueError(err_str)

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -343,71 +343,20 @@ def open_raster(filename, band=1):
         arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
     except:
-        # GDAL reads 1st 2 bytes of ENVI binary to determine type. If 1st bytes
-        # of flat binary is that of a jpeg but the binary is not then GDAL
-        # throws a libjpeg runtime error. Kluge that follows is a workaround.
         pass
 
-    # If GDAL load fails, if ENVI and try to load binary raster with numpy
-    # Following bool will be True if kluge works. Will be checked in try/except
-    kluge_load_success = False
-    arr = []
-
-    # Get header name from filename
-    header_file = os.path.splitext(filename)[0] + '.hdr'
-    if not os.path.isfile(header_file):
-        err_append = "no ENVI header found"
-    else:
-        with open(header_file, 'r') as fh_header:
-            # Load all header lines
-            hdr_info = [line[:-1] for line in fh_header.readlines()]
-
-            # Check if file type is ENVI
-            is_envi = hdr_info[0] == 'ENVI'
-            if not is_envi and len(hdr_info) != 9:
-                if not is_envi:
-                    err_append = "GDAL unable to load raster file"
-                else:
-                    err_append = "not correct number lines in ENVI header"
-            else:
-                def _get_int_from_envi_hdr_line(line, name):
-                    # Check and get int value of element name
-                    # If name in line, then get int value at end
-                    if f'{name}' in line:
-                        return int(line.split()[-1])
-
-                    # Return invalid value of -1
-                    return -1
-
-                # Get values for elements needed by np.fromfile
-                inds_of_interest = [1, 2, 6]
-                names_of_interest = ['samples', 'lines' ,'data type']
-                arr_params = [_get_int_from_envi_hdr_line(hdr_info[i],
-                                                          element_name)
-                              for i, element_name in zip(inds_of_interest,
-                                                         names_of_interest)]
-
-                # Check all values > 0 i.e. valid
-                if not all([x > 0 for x in arr_params]):
-                    err_append = "ENVI header array params bad"
-                else:
-                    samples, lines, dtype_envi = arr_params
-
-                    # Covert ENVI type to numpy type
-                    dtype_dict ={1: np.byte, 2: np.intc, 3: np.int_,
-                                 4: np.single, 5: np.double}
-                    dtype = dtype_dict[dtype_envi]
-
-                    arr = np.fromfile(filename, dtype=dtype).reshape(lines,
-                                                                     samples)
-                    kluge_load_success = True
-
+    # GDAL reads 1st 2 bytes of ENVI binary to determine file type. If 1st
+    # bytes of flat binary is that of a jpeg but the binary is not then GDAL
+    # throws a libjpeg runtime error. Follow specifically tries to load as an
+    # ENVI file.
     try:
-        assert kluge_load_success
+        ds = gdal.OpenEx(filename, gdal.OF_VERBOSE_ERROR,
+                         allowed_drivers=['ENVI'])
+        arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
     except:
         error_channel = journal.error('helpers.open_raster')
-        err_str = f'{filename} cannot be opened by GDAL nor numpy: {err_append}'
+        err_str = f'{filename} cannot be opened by GDAL'
         error_channel.log(err_str)
         raise ValueError(err_str)
 

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -338,9 +338,13 @@ def open_raster(filename, band=1):
     raster: np.ndarray
         Numpy array containing the raster band to open
     '''
-
-    ds = gdal.Open(filename, gdal.GA_ReadOnly)
-    raster = ds.GetRasterBand(band).ReadAsArray()
+    try:
+        ds = gdal.Open(filename, gdal.GA_ReadOnly)
+        raster = ds.GetRasterBand(band).ReadAsArray()
+    except ValueError:
+        err_str = f'{filename} cannot be opened by GDAL'
+        error_channel.log(err_str)
+        raise ValueError(err_str)
 
     return raster
 

--- a/src/compass/utils/validate_product.py
+++ b/src/compass/utils/validate_product.py
@@ -55,8 +55,6 @@ def _grid_info_retrieve(path_h5, dataset_names, is_static_layer):
         Map projection of the raster in WKT
     """
     data_path = DATA_PATH
-    if is_static_layer:
-        data_path += '/static_layers'
 
     # Extract existing dataset names with h5py
     with h5py.File(path_h5, 'r') as h:


### PR DESCRIPTION
This PR:
* wraps `gdal.Open` in `compass.utils.helpers.open_raster` with `try/catch` and provide meaningful error message on failure
* fix path bug in `validate_product`
* fixes edge case when `gdal.Open` tries to load a rdr2geo ENVI binary whose 1st two bytes match those of a JPG by using `gdal.OpenEx` after first `try/except`