### PR TITLE
`0.3.0` -> `0.3.1`

### DIFF
--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,6 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.3.1', '2023-06-01'),
     Tag('0.3.0', '2023-05-31'),
     Tag('0.1.5', '2023-05-10'),
     Tag('0.1.4', '2023-03-23'),


### PR DESCRIPTION
This is a PR to bump the version after applying the fix in #164 