### PR TITLE
Add separate generation of CSLC-S1 static layers

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -71,8 +71,6 @@ runconfig:
                  delay_type: wet_dry
 
           rdr2geo:
-              # Enable/disable computation of topo layers
-              enabled: False
               # Convergence threshold for rdr2geo algorithm
               threshold: 1.0e-8
               # Maximum number of iterations
@@ -95,8 +93,6 @@ runconfig:
               compute_local_incidence_angle: True
               # Enable/disable azimuth angle output
               compute_azimuth_angle: True
-              # Enable/disable generation of the topo layers
-              geocode_metadata_layers: True
 
       worker:
           # Optional. To prevent downloading DEM or other data (default: False)

--- a/src/compass/s1_cslc.py
+++ b/src/compass/s1_cslc.py
@@ -2,7 +2,8 @@
 
 '''driver for CSLC workflow in radar/geo'''
 
-from compass import s1_rdr2geo, s1_geo2rdr, s1_resample, s1_geocode_slc, s1_static_layers
+from compass import (s1_rdr2geo, s1_geo2rdr, s1_resample,
+                     s1_geocode_slc, s1_static_layers)
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.runconfig import RunConfig
 from compass.utils.yaml_argparse import YamlArgparse

--- a/src/compass/s1_cslc.py
+++ b/src/compass/s1_cslc.py
@@ -2,7 +2,7 @@
 
 '''driver for CSLC workflow in radar/geo'''
 
-from compass import s1_rdr2geo, s1_geo2rdr, s1_resample, s1_geocode_slc
+from compass import s1_rdr2geo, s1_geo2rdr, s1_resample, s1_geocode_slc, s1_static_layers
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.runconfig import RunConfig
 from compass.utils.yaml_argparse import YamlArgparse
@@ -39,8 +39,11 @@ def run(run_config_path: str, grid_type: str):
         # get a runconfig dict from command line argumens
         cfg = GeoRunConfig.load_from_yaml(run_config_path, 's1_cslc_geo')
 
-        # run geocode_slc
-        s1_geocode_slc.run(cfg)
+        # Check if product_type is CSLC-S1, and produce product only
+        if cfg.product_type == 'CSLC_S1':
+            s1_geocode_slc.run(cfg)
+        else:
+            s1_static_layers.run(cfg)
 
 
 def main():

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -15,6 +15,17 @@ def _make_rdr2geo_cfg(yaml_runconfig_str):
     Make a rdr2geo specific runconfig with latitude, longitude, and height
     layers enabled for static layer product generation while preserving all
     other rdr2geo config settings
+
+    Parameters
+    ----------
+    yaml_runconfig_str: str
+        Workflow runconfig as a string
+
+    Returns
+    -------
+    rdr2geo_cfg: dict
+        Dictionary with rdr2geo longitude, latitude, and height layers
+        enabled. All other rdr2geo parameters are from *yaml_runconfig_str*
     '''
     # If any of the requisite layers are false, make them true in yaml cfg str
     for layer in ['latitude', 'longitude', 'incidence_angle']:

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -30,7 +30,8 @@ def _make_rdr2geo_cfg(yaml_runconfig_str):
 
 def run(cfg: GeoRunConfig):
     '''
-    Run geocode burst workflow with user-defined
+    Run static layers workflow (i.e., generate static layers,
+    geocode them, create product HDF5) with user-defined
     args stored in dictionary runconfig *cfg*
 
     Parameters

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -56,7 +56,7 @@ def run(cfg: GeoRunConfig):
     info_channel.log(f"Starting {module_name} burst")
 
     # Start tracking processing time
-    t_start = time.time()
+    t_start = time.perf_counter()
 
     for burst_id, bursts in bursts_grouping_generator(cfg.bursts):
         burst = bursts[0]

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -1,0 +1,75 @@
+import journal
+import re
+import time
+
+from datetime import timedelta
+from compass.utils.geo_runconfig import GeoRunConfig
+from compass.utils.yaml_argparse import YamlArgparse
+from compass.utils.helpers import bursts_grouping_generator, get_module_name
+from compass import s1_rdr2geo
+from compass import s1_geocode_metadata
+
+
+def _make_rdr2geo_cfg(yaml_runconfig_str):
+    '''
+    Make a rdr2geo specific runconfig with latitude, longitude, and height
+    layers enabled for static layer product generation while preserving all
+    other rdr2geo config settings
+    '''
+    # If any of the requisite layers are false, make them true in yaml cfg str
+    for layer in ['latitude', 'longitude', 'incidence_angle']:
+        re.sub(f'compute_{layer}:\s+[Ff]alse', f'compute_{layer}: true',
+               yaml_runconfig_str)
+
+    # Load a GeoRunConfig from modified yaml cfg string
+    rdr2geo_cfg = GeoRunConfig.load_from_yaml(yaml_runconfig_str,
+                                              workflow_name='s1_cslc_geo')
+
+    return rdr2geo_cfg
+
+
+def run(cfg: GeoRunConfig):
+    '''
+    Run geocode burst workflow with user-defined
+    args stored in dictionary runconfig *cfg*
+
+    Parameters
+    ---------
+    cfg: GeoRunConfig
+        GeoRunConfig object with user runconfig options
+    '''
+
+    module_name = get_module_name(__file__)
+    info_channel = journal.info(f"{module_name}.run")
+    info_channel.log(f"Starting {module_name} burst")
+
+    # Start tracking processing time
+    t_start = time.time()
+
+    for burst_id, bursts in bursts_grouping_generator(cfg.bursts):
+        burst = bursts[0]
+
+        date_str = burst.sensing_start.strftime("%Y%m%d")
+
+        info_channel.log(f'Starting geocoding of {burst_id} for {date_str}')
+
+        # Generate required static layers
+        rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
+        s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
+        s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
+
+    dt = str(timedelta(seconds=time.time() - t_start)).split(".")[0]
+    info_channel.log(f"{module_name} burst successfully ran in {dt} (hr:min:sec)")
+
+
+if __name__ == "__main__":
+    '''Run CSLC static layers workflow from command line'''
+    # load arguments from command line
+    parser = YamlArgparse()
+
+    # Get a runconfig dict from command line arguments
+    cfg = GeoRunConfig.load_from_yaml(parser.run_config_path,
+                                      workflow_name='s1_cslc_geo')
+
+    # Run geocode burst workflow
+    run(cfg)

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -63,7 +63,6 @@ def run(cfg: GeoRunConfig):
 
 
 if __name__ == "__main__":
-    '''Run CSLC static layers workflow from command line'''
     # load arguments from command line
     parser = YamlArgparse()
 

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -40,7 +40,7 @@ runconfig:
            product_specification_version: str(required=False)
 
         primary_executable:
-          product_type: enum('CSLC_S1', 'CSLC_S1_SL')
+          product_type: enum('CSLC_S1', 'CSLC_S1_STATIC')
 
         # This section includes parameters to tweak the workflow
         processing: include('processing_options', required=False)

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -40,7 +40,7 @@ runconfig:
            product_specification_version: str(required=False)
 
         primary_executable:
-          product_type: enum('CSLC_S1')
+          product_type: enum('CSLC_S1', 'CSLC_S1_SL')
 
         # This section includes parameters to tweak the workflow
         processing: include('processing_options', required=False)
@@ -103,8 +103,6 @@ troposphere_options:
   delay_type: enum('dry', 'wet', 'wet_dry', required=False)
 
 rdr2geo_options:
-    # Enable/disable computation of topo layers
-    enabled: bool(required=False)
     # Convergence threshold for rdr2geo algorithm
     threshold: num(min=0, required=False)
     # Maximum number of iterations
@@ -127,8 +125,6 @@ rdr2geo_options:
     compute_local_incidence_angle: bool(required=False)
     # Enable/disable azimuth angle output
     compute_azimuth_angle: bool(required=False)
-    # Enable/disable geocoding of the topo layers
-    geocode_metadata_layers: bool(required=False)
 
 worker_options:
     # To prevent downloading DEM / other data automatically. Default True

--- a/src/compass/utils/geo_runconfig.py
+++ b/src/compass/utils/geo_runconfig.py
@@ -121,6 +121,10 @@ class GeoRunConfig(RunConfig):
         return self.groups.product_path_group
 
     @property
+    def product_type(self) -> dict:
+        return self.groups.primary_executable.product_type
+
+    @property
     def weather_model_file(self) -> str:
         return self.groups.dynamic_ancillary_file_group.weather_model_file
 

--- a/tests/data/geo_cslc_s1_template.yaml
+++ b/tests/data/geo_cslc_s1_template.yaml
@@ -17,8 +17,6 @@ runconfig:
     primary_executable:
       product_type: CSLC_S1
     processing:
-      rdr2geo:
-        enabled: false
       geo2rdr:
         lines_per_block: 1000
         numiter: 25


### PR DESCRIPTION
This PR allows the SAS CSLC-S1 to independently generate the static layers product. Therefore, the new CSLC-S1 SAS behavior is the following:

1. when `product_type: CSLC_S1`, the SAS generates only the CSLC-S1 product
2. when `product_type: CSLC_S1_STATIC`, the SAS generates only the CSLC-S1 static layers product

Flags to run rdr2geo and geocode the static layers have been removed from the schema. The default SAS `product_type` has been set to always generate the CSLC-S1 product.

Note: would be good if this PR can be merged ASAP so that the integration of the LOS vectors into the CSLC-S1 static layers workflow will be much easier. Thank you :)