### PR TITLE
change `types` import location

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -31,7 +31,7 @@ from compass.utils.lut import cumulative_correction_luts
 from compass.utils.yaml_argparse import YamlArgparse
 
 # TEMPORARY MEASURE TODO refactor types functions to isce3 namespace
-from nisar.types import (truncate_mantissa, to_complex32)
+from isce3.core.types import (truncate_mantissa, to_complex32)
 
 def _make_rdr2geo_cfg(yaml_runconfig_str):
     '''


### PR DESCRIPTION
This PR changes `types` import location from `nisar` to `isce3.core` to reflect changes made in this [PR](https://github-fn.jpl.nasa.gov/isce-3/isce/pull/1397).