### PR TITLE
Wrap the carrier phase and flattening phase right before writing it

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -243,14 +243,14 @@ def run(cfg: GeoRunConfig):
                                       rg_carrier=isce3.core.Poly2d(np.array([0])),
                                       az_time_correction=az_lut,
                                       srange_correction=rg_lut,
-                                      carrier_phase_block=_wrap_phase(carrier_phase_data_blk),
-                                      flatten_phase_block=_wrap_phase(flatten_phase_data_blk))
+                                      carrier_phase_block=carrier_phase_data_blk,
+                                      flatten_phase_block=flatten_phase_data_blk)
 
             # write geocoded data blocks to respective HDF5 datasets
             geo_datasets.extend([carrier_phase_ds,
                                  flatten_phase_ds])
-            geo_data_blks.extend([carrier_phase_data_blk,
-                                  flatten_phase_data_blk])
+            geo_data_blks.extend([_wrap_phase(carrier_phase_data_blk),
+                                  _wrap_phase(flatten_phase_data_blk)])
             for cslc_dataset, cslc_data_blk in zip(geo_datasets,
                                                    geo_data_blks):
                 # only convert/modify output if type not 'complex64'


### PR DESCRIPTION
This PR is an attempt to fix the issue of having empty arrays for azimuth carrier phase and flattening phase. The fix is to retrieve unwrapped phases from `isce3.geocode.geocode_slc`, and wrap if before applying the truncation and writing it into HDF file.