### PR TITLE
WIP: Integrate LOS vector in CSLC-S1 static layers product

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -86,12 +86,8 @@ runconfig:
               compute_height: False
               # Enable/disable layover shadow mask output
               compute_layover_shadow_mask: True
-              # Enable/disable incidence angle output
-              compute_incidence_angle: True
               # Enable/disable local incidence output
               compute_local_incidence_angle: True
-              # Enable/disable azimuth angle output
-              compute_azimuth_angle: False
               # Enable/disable ground to satellite East LOS vector
               compute_ground_to_sat_east: True
               # Enable/disable ground to satellite North LOS vector

--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -91,7 +91,11 @@ runconfig:
               # Enable/disable local incidence output
               compute_local_incidence_angle: True
               # Enable/disable azimuth angle output
-              compute_azimuth_angle: True
+              compute_azimuth_angle: False
+              # Enable/disable ground to satellite East LOS vector
+              compute_ground_to_sat_east: True
+              # Enable/disable ground to satellite North LOS vector
+              compute_ground_to_sat_north: True
 
       worker:
           # Optional. To prevent downloading DEM or other data (default: False)

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -10,8 +10,7 @@ import numpy as np
 
 from compass.s1_rdr2geo import (file_name_los_east,
                                 file_name_los_north,file_name_local_incidence,
-                                file_name_layover, file_name_x,
-                                file_name_y, file_name_z)
+                                file_name_x, file_name_y, file_name_z)
 from compass.utils.h5_helpers import (DATA_PATH, METADATA_PATH, TIME_STR_FMT,
                                       QA_PATH, add_dataset_and_attrs, Meta)
 

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -128,7 +128,10 @@ class QualityAssuranceCSLC:
         # path to source group
         static_layer_path = f'{DATA_PATH}'
 
-        # Get the static layer to compute stats for
+        # Get the static layer to compute stats
+        # Following dict tracks which static layers to generate
+        # key: file name of static layer
+        # value: bool flag from runconfig that determines if layer is computed
         static_layers_dict = {
             file_name_x: rdr2geo_params.compute_longitude,
             file_name_y: rdr2geo_params.compute_latitude,

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -8,6 +8,10 @@ from pathlib import Path
 import isce3
 import numpy as np
 
+from compass.s1_rdr2geo import (file_name_los_east,
+                                file_name_los_north,file_name_local_incidence,
+                                file_name_layover, file_name_x,
+                                file_name_y, file_name_z)
 from compass.utils.h5_helpers import (DATA_PATH, METADATA_PATH, TIME_STR_FMT,
                                       QA_PATH, add_dataset_and_attrs, Meta)
 
@@ -127,12 +131,12 @@ class QualityAssuranceCSLC:
 
         # Get the static layer to compute stats for
         static_layers_dict = {
-            'x': rdr2geo_params.compute_longitude,
-            'y': rdr2geo_params.compute_latitude,
-            'z': rdr2geo_params.compute_height,
-            'incidence_angle': rdr2geo_params.compute_incidence_angle,
-            'local_incidence_angle': rdr2geo_params.compute_local_incidence_angle,
-            'heading_angle': rdr2geo_params.compute_azimuth_angle
+            file_name_x: rdr2geo_params.compute_longitude,
+            file_name_y: rdr2geo_params.compute_latitude,
+            file_name_z: rdr2geo_params.compute_height,
+            file_name_local_incidence: rdr2geo_params.compute_local_incidence_angle,
+            file_name_los_east: rdr2geo_params.compute_ground_to_sat_east,
+            file_name_los_north: rdr2geo_params.compute_ground_to_sat_north
         }
         static_layers = [key for key, val in static_layers_dict.items()
                          if val]

--- a/src/compass/s1_geo2rdr.py
+++ b/src/compass/s1_geo2rdr.py
@@ -28,7 +28,7 @@ def run(cfg: dict):
     info_channel.log(f'Starting {module_name} burst')
 
     # Tracking time elapsed for processing
-    t_start = time.time()
+    t_start = time.perf_counter()
 
     # Common initializations for different bursts
     dem_raster = isce3.io.Raster(cfg.dem)

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -81,7 +81,7 @@ def run(cfg, burst, fetch_from_scratch=False):
     info_channel.log(f"Starting {module_name} burst")
 
     # Start tracking processing time
-    t_start = time.time()
+    t_start = time.perf_counter()
 
     # common initializations
     dem_raster = isce3.io.Raster(cfg.dem)
@@ -138,10 +138,10 @@ def run(cfg, burst, fetch_from_scratch=False):
                              'incidence'),
          'local_incidence_angle': (cfg.rdr2geo_params.compute_local_incidence_angle,
                                    'local_incidence'),
-         'heading_angle': (cfg.rdr2geo_params.compute_azimuth_angle,
-                           'heading'),
-         'layover_shadow_mask': (cfg.rdr2geo_params.compute_layover_shadow_mask,
-                                 'layover_shadow_mask')
+         'east_los_vector': (cfg.rdr2geo_params.compute_ground_to_sat_east,
+                            'los_east'),
+         'north_los_vector': (cfg.rdr2geo_params.compute_ground_to_sat_north,
+                              'los_north')
          }
 
     out_h5 = f'{out_paths.output_directory}/static_layers_{burst_id}.h5'

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -12,6 +12,10 @@ from osgeo import gdal
 from scipy.interpolate import InterpolatedUnivariateSpline
 
 from compass import s1_rdr2geo
+from compass.s1_rdr2geo import (file_name_los_east,
+                                file_name_los_north,file_name_local_incidence,
+                                file_name_layover, file_name_x,
+                                file_name_y, file_name_z)
 from compass.s1_cslc_qa import QualityAssuranceCSLC
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.h5_helpers import (algorithm_metadata_to_h5group,
@@ -131,17 +135,17 @@ def run(cfg, burst, fetch_from_scratch=False):
     # key: dataset name
     # value: (bool flag if dataset is to written, raster layer name)
     static_layers = \
-        {'x': (cfg.rdr2geo_params.compute_longitude, 'x'),
-         'y': (cfg.rdr2geo_params.compute_latitude, 'y'),
-         'z': (cfg.rdr2geo_params.compute_height, 'z'),
-         'incidence_angle': (cfg.rdr2geo_params.compute_incidence_angle,
-                             'incidence'),
-         'local_incidence_angle': (cfg.rdr2geo_params.compute_local_incidence_angle,
-                                   'local_incidence'),
-         'east_los_vector': (cfg.rdr2geo_params.compute_ground_to_sat_east,
-                            'los_east'),
-         'north_los_vector': (cfg.rdr2geo_params.compute_ground_to_sat_north,
-                              'los_north')
+        {file_name_x: (cfg.rdr2geo_params.compute_longitude, 'x'),
+         file_name_y: (cfg.rdr2geo_params.compute_latitude, 'y'),
+         file_name_z: (cfg.rdr2geo_params.compute_height, 'z'),
+         file_name_local_incidence: (cfg.rdr2geo_params.compute_local_incidence_angle,
+                                    'local_incidence'),
+         file_name_los_east: (cfg.rdr2geo_params.compute_ground_to_sat_east,
+                             'los_east'),
+         file_name_los_north: (cfg.rdr2geo_params.compute_ground_to_sat_north,
+                              'los_north'),
+         file_name_layover: (cfg.rdr2geo_params.compute_layover_shadow_mask,
+                             'layover_shadow_mask')
          }
 
     out_h5 = f'{out_paths.output_directory}/static_layers_{burst_id}.h5'

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -13,7 +13,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline
 
 from compass import s1_rdr2geo
 from compass.s1_rdr2geo import (file_name_los_east,
-                                file_name_los_north,file_name_local_incidence,
+                                file_name_los_north, file_name_local_incidence,
                                 file_name_layover, file_name_x,
                                 file_name_y, file_name_z)
 from compass.s1_cslc_qa import QualityAssuranceCSLC

--- a/src/compass/s1_geocode_stack.py
+++ b/src/compass/s1_geocode_stack.py
@@ -403,7 +403,7 @@ def run(slc_dir, dem_file, burst_id=None, common_bursts_only=False, start_date=N
         Flag to indicate if SAFE files are zipped or not (default: True).
         Will search for .zip files if True, and .SAFE directories if False.
     """
-    start_time = time.time()
+    start_time = time.perf_counter()
     error = journal.error('s1_geo_stack_processor.main')
     info = journal.info('s1_geo_stack_processor.main')
 
@@ -476,7 +476,7 @@ def run(slc_dir, dem_file, burst_id=None, common_bursts_only=False, start_date=N
             rsh.write(
                 f'python {path}/s1_cslc.py {runconfig_path}\n')
 
-    end_time = time.time()
+    end_time = time.perf_counter()
     print('Elapsed time (min):', (end_time - start_time) / 60.0)
 
 

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -103,7 +103,9 @@ def run(cfg, burst=None, save_in_scratch=False):
                               extraiter=rdr2geo_cfg.extraiter,
                               lines_per_block=rdr2geo_cfg.lines_per_block)
 
-        # prepare output rasters
+        # Dict containing the rdr2geo layers to generate and their filenames
+        # key: rdr2geo layer name
+        # value: (boolean flag; True if layers needs to be generated, layer name)
         topo_output = {'x': (rdr2geo_cfg.compute_longitude, gdal.GDT_Float64),
                        'y': (rdr2geo_cfg.compute_latitude, gdal.GDT_Float64),
                        'z': (rdr2geo_cfg.compute_height, gdal.GDT_Float64),

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -31,7 +31,7 @@ def run(cfg, burst=None, save_in_scratch=False):
     info_channel.log(f"Starting {module_name} burst")
 
     # Tracking time elapsed for processing
-    t_start = time.time()
+    t_start = time.perf_counter()
 
     # Extract rdr2geo cfg
     rdr2geo_cfg = cfg.rdr2geo_params
@@ -116,7 +116,12 @@ def run(cfg, burst=None, save_in_scratch=False):
                        rdr2geo_cfg.compute_local_incidence_angle,
                        gdal.GDT_Float32),
                        'heading': (
-                       rdr2geo_cfg.compute_azimuth_angle, gdal.GDT_Float32)}
+                       rdr2geo_cfg.compute_azimuth_angle, gdal.GDT_Float32),
+                       'los_east': (
+                       rdr2geo_cfg.compute_ground_to_sat_east, gdal.GDT_Float32),
+                       'los_north': (
+                       rdr2geo_cfg.compute_ground_to_sat_north, gdal.GDT_Float32),
+                       }
         raster_list = [
             isce3.io.Raster(f'{output_path}/{fname}.rdr', rdr_grid.width,
                             rdr_grid.length, 1, dtype, 'ENVI')
@@ -125,7 +130,8 @@ def run(cfg, burst=None, save_in_scratch=False):
 
         x_raster, y_raster, z_raster, layover_shadow_raster, \
         incident_angle_raster, local_incident_angle_raster, \
-        azimuth_angle_raster = raster_list
+        azimuth_angle_raster, los_east_raster,\
+        los_north_raster = raster_list
 
         # run rdr2geo
         rdr2geo_obj.topo(dem_raster, x_raster=x_raster, y_raster=y_raster,
@@ -133,7 +139,9 @@ def run(cfg, burst=None, save_in_scratch=False):
                          incidence_angle_raster=incident_angle_raster,
                          local_incidence_angle_raster=local_incident_angle_raster,
                          heading_angle_raster=azimuth_angle_raster,
-                         layover_shadow_raster=layover_shadow_raster)
+                         layover_shadow_raster=layover_shadow_raster,
+                         ground_to_sat_east_raster=los_east_raster,
+                         ground_to_sat_north_raster=los_north_raster)
 
         # remove undesired/None rasters from raster list
         raster_list = [raster for raster in raster_list if raster is not None]

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -134,9 +134,9 @@ def run(cfg, burst=None, save_in_scratch=False):
             if enabled else None
             for fname, (enabled, dtype) in topo_output.items()]
 
-        x_raster, y_raster, z_raster, layover_shadow_raster, \
-        local_incident_angle_raster, los_east_raster,\
-        los_north_raster = raster_list
+        (x_raster, y_raster, z_raster, layover_shadow_raster,
+         local_incident_angle_raster, los_east_raster,
+         los_north_raster) = raster_list
 
         # run rdr2geo
         rdr2geo_obj.topo(dem_raster, x_raster=x_raster, y_raster=y_raster,

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -13,6 +13,14 @@ from compass.utils.radar_grid import rdr_grid_to_file
 from compass.utils.runconfig import RunConfig
 from compass.utils.yaml_argparse import YamlArgparse
 
+file_name_los_east = 'los_east'
+file_name_los_north = 'los_north'
+file_name_local_incidence = 'local_incidence'
+file_name_layover = 'layover_shadow_mask'
+file_name_x = 'x'
+file_name_y = 'y'
+file_name_z = 'z'
+
 
 def run(cfg, burst=None, save_in_scratch=False):
     '''run rdr2geo with provided runconfig
@@ -106,22 +114,18 @@ def run(cfg, burst=None, save_in_scratch=False):
         # Dict containing the rdr2geo layers to generate and their filenames
         # key: rdr2geo layer name
         # value: (boolean flag; True if layers needs to be generated, layer name)
-        topo_output = {'x': (rdr2geo_cfg.compute_longitude, gdal.GDT_Float64),
-                       'y': (rdr2geo_cfg.compute_latitude, gdal.GDT_Float64),
-                       'z': (rdr2geo_cfg.compute_height, gdal.GDT_Float64),
-                       'layover_shadow_mask': (
+        topo_output = {file_name_x: (rdr2geo_cfg.compute_longitude, gdal.GDT_Float64),
+                       file_name_y: (rdr2geo_cfg.compute_latitude, gdal.GDT_Float64),
+                       file_name_z: (rdr2geo_cfg.compute_height, gdal.GDT_Float64),
+                       file_name_layover: (
                        cfg.rdr2geo_params.compute_layover_shadow_mask,
                        gdal.GDT_Byte),
-                       'incidence': (rdr2geo_cfg.compute_incidence_angle,
-                                     gdal.GDT_Float32),
-                       'local_incidence': (
+                       file_name_local_incidence: (
                        rdr2geo_cfg.compute_local_incidence_angle,
                        gdal.GDT_Float32),
-                       'heading': (
-                       rdr2geo_cfg.compute_azimuth_angle, gdal.GDT_Float32),
-                       'los_east': (
+                       file_name_los_east: (
                        rdr2geo_cfg.compute_ground_to_sat_east, gdal.GDT_Float32),
-                       'los_north': (
+                       file_name_los_north: (
                        rdr2geo_cfg.compute_ground_to_sat_north, gdal.GDT_Float32),
                        }
         raster_list = [
@@ -131,16 +135,13 @@ def run(cfg, burst=None, save_in_scratch=False):
             for fname, (enabled, dtype) in topo_output.items()]
 
         x_raster, y_raster, z_raster, layover_shadow_raster, \
-        incident_angle_raster, local_incident_angle_raster, \
-        azimuth_angle_raster, los_east_raster,\
+        local_incident_angle_raster, los_east_raster,\
         los_north_raster = raster_list
 
         # run rdr2geo
         rdr2geo_obj.topo(dem_raster, x_raster=x_raster, y_raster=y_raster,
                          height_raster=z_raster,
-                         incidence_angle_raster=incident_angle_raster,
                          local_incidence_angle_raster=local_incident_angle_raster,
-                         heading_angle_raster=azimuth_angle_raster,
                          layover_shadow_raster=layover_shadow_raster,
                          ground_to_sat_east_raster=los_east_raster,
                          ground_to_sat_north_raster=los_north_raster)

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -28,7 +28,7 @@ def run(cfg: dict):
     info_channel.log(f"Starting {module_name} burst")
 
     # Tracking time elapsed for processing
-    t_start = time.time()
+    t_start = time.perf_counter()
 
     # Check if user wants to use GPU for processing
     # Instantiate and initialize resample object

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -68,7 +68,7 @@ def run(cfg: GeoRunConfig):
         # Generate required static layers
         rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
         s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
-        s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
+        #s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
 
     dt = str(timedelta(seconds=time.time() - t_start)).split(".")[0]
     info_channel.log(f"{module_name} burst successfully ran in {dt} (hr:min:sec)")

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -5,7 +5,8 @@ import time
 from datetime import timedelta
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.yaml_argparse import YamlArgparse
-from compass.utils.helpers import bursts_grouping_generator, get_module_name
+from compass.utils.helpers import (bursts_grouping_generator, get_module_name,
+                                   get_time_delta_str)
 from compass import s1_rdr2geo
 from compass import s1_geocode_metadata
 
@@ -70,7 +71,7 @@ def run(cfg: GeoRunConfig):
         s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
         s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
 
-    dt = str(timedelta(seconds=time.time() - t_start)).split(".")[0]
+    dt = get_time_delta_str(t_start)
     info_channel.log(f"{module_name} burst successfully ran in {dt} (hr:min:sec)")
 
 

--- a/src/compass/s1_static_layers.py
+++ b/src/compass/s1_static_layers.py
@@ -68,7 +68,7 @@ def run(cfg: GeoRunConfig):
         # Generate required static layers
         rdr2geo_cfg = _make_rdr2geo_cfg(cfg.yaml_string)
         s1_rdr2geo.run(rdr2geo_cfg, burst, save_in_scratch=True)
-        #s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
+        s1_geocode_metadata.run(cfg, burst, fetch_from_scratch=True)
 
     dt = str(timedelta(seconds=time.time() - t_start)).split(".")[0]
     info_channel.log(f"{module_name} burst successfully ran in {dt} (hr:min:sec)")

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -127,6 +127,10 @@ rdr2geo_options:
     compute_local_incidence_angle: bool(required=False)
     # Enable/disable azimuth angle output
     compute_azimuth_angle: bool(required=False)
+    # Enable/disable ground to satellite East LOS vector
+    compute_ground_to_sat_east: bool(required=True)
+    # Enable/disable ground to satellite North LOS vector
+    compute_ground_to_sat_north: bool(required=False)
 
 worker_options:
     # To prevent downloading DEM / other data automatically. Default True

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -121,12 +121,8 @@ rdr2geo_options:
     compute_height: bool(required=False)
     # Enable/disable layover shadow mask output
     compute_layover_shadow_mask: bool(required=False)
-    # Enable/disable incidence angle output
-    compute_incidence_angle: bool(required=False)
     # Enable/disable local incidence output
     compute_local_incidence_angle: bool(required=False)
-    # Enable/disable azimuth angle output
-    compute_azimuth_angle: bool(required=False)
     # Enable/disable ground to satellite East LOS vector
     compute_ground_to_sat_east: bool(required=False)
     # Enable/disable ground to satellite North LOS vector

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -128,7 +128,7 @@ rdr2geo_options:
     # Enable/disable azimuth angle output
     compute_azimuth_angle: bool(required=False)
     # Enable/disable ground to satellite East LOS vector
-    compute_ground_to_sat_east: bool(required=True)
+    compute_ground_to_sat_east: bool(required=False)
     # Enable/disable ground to satellite North LOS vector
     compute_ground_to_sat_north: bool(required=False)
 


### PR DESCRIPTION
This PR integrates the LOS vector in the CSLC-S1 static layers product. Specifically, the PR removes the heading_angle layer and adds east_los_vector and north_los_vector.

TO DOs:

- [x] 1. Merge ISCE3 PR computing LOS vectors in Topo
- [x] 2. Test if the correct LOS vectors are returned for a couple of test bursts
- [x] 3. Remove `incidence_angle` and `heading`
- [x] 4. Check generated static layers product
- [ ] 5. Modify static layers product specifications