### PR TITLE
append `_angle` to `local_incidence`

### DIFF
--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -144,7 +144,7 @@ def run(cfg, burst, fetch_from_scratch=False):
          file_name_z: (cfg.rdr2geo_params.compute_height, 'z',
                        'Height in meters'),
          file_name_local_incidence: (cfg.rdr2geo_params.compute_local_incidence_angle,
-                                    'local_incidence',
+                                    'local_incidence_angle',
                                      'Local incidence angle in degrees'),
          file_name_los_east: (cfg.rdr2geo_params.compute_ground_to_sat_east,
                              'los_east',


### PR DESCRIPTION
This PR fixes local incidence metadata dataset name by appending `_angle` to `local_incidence`.