### PR TITLE
Remove spurious flattening metadata from CSLC-S1

### DIFF
--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -20,7 +20,6 @@ from compass.utils.elevation_antenna_pattern import apply_eap_correction
 from compass.utils.geo_runconfig import GeoRunConfig
 from compass.utils.h5_helpers import (algorithm_metadata_to_h5group,
                                       corrections_to_h5group,
-                                      flatten_metadata_to_h5group,
                                       identity_to_h5group,
                                       init_geocoded_dataset,
                                       metadata_to_h5group,
@@ -255,7 +254,6 @@ def run(cfg: GeoRunConfig):
             metadata_to_h5group(root_group, burst, cfg,
                                 eap_correction_applied=check_eap.phase_correction)
             algorithm_metadata_to_h5group(root_group)
-            flatten_metadata_to_h5group(root_group, cfg)
             if cfg.lut_params.enabled:
                 correction_group = geo_burst_h5.require_group(
                     f'{METADATA_PATH}/processing_information')

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -465,7 +465,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
 
     # Get orbit type
     orbit_file_path = os.path.basename(cfg.orbit_path[0])
-    print(orbit_file_path)
+
     if 'RESORB' in orbit_file_path:
         orbit_type = 'RESORB'
     if 'POEORB' in orbit_file_path:

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -465,6 +465,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
 
     # Get orbit type
     orbit_file_path = os.path.basename(cfg.orbit_path[0])
+    print(orbit_file_path)
     if 'RESORB' in orbit_file_path:
         orbit_type = 'RESORB'
     if 'POEORB' in orbit_file_path:
@@ -675,32 +676,6 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
 
     poly1d_to_h5(burst_meta_group, 'azimuth_fm_rate', burst.azimuth_fm_rate)
     poly1d_to_h5(burst_meta_group, 'doppler', burst.doppler.poly1d)
-
-
-def flatten_metadata_to_h5group(parent_group, cfg):
-    '''
-    Write burst flattening metadata to HDF5
-
-    Parameter:
-    ---------
-    parent_group: h5py Group
-        HDF5 group Meta data will be written to
-    cfg: types.SimpleNamespace
-        SimpleNamespace containing run configuration
-    '''
-    # Add parameters group in processing information
-    par_meta_items = [
-        Meta('ellipsoidalFlatteningApplied', cfg.geocoding_params.flatten,
-             "If True, CSLC-S1 phase has been flatten with respect to a zero height ellipsoid",
-             {'units':'unitless'}),
-        Meta('topographicFlatteningApplied', cfg.geocoding_params.flatten,
-             "If True, CSLC-S1 phase has been flatten with respect to topographic height using a DEM",
-             {'units': 'unitless'}),
-    ]
-    par_meta_group = \
-        parent_group.require_group('metadata/processing_information/parameters')
-    for meta_item in par_meta_items:
-        add_dataset_and_attrs(par_meta_group, meta_item)
 
 
 def algorithm_metadata_to_h5group(parent_group, is_static_layers=False):


### PR DESCRIPTION
This PR removes extra spurious flattening metadata i.e., `ellipsoidalFlatteningApplied` and `topographicFlatteningApplied ` which were erroneously put in the product and they do not meet the snake case convention we have decided to adopt. 