### PR TITLE
replace some leftover f-string path construction

### DIFF
--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -74,7 +74,6 @@ def run(cfg, burst=None, save_in_scratch=False):
         # extract date string and create directory
         date_str = burst.sensing_start.strftime("%Y%m%d")
         burst_id = str(burst.burst_id)
-        pol = burst.polarization
 
         # init output directory in product_path
         burst_id_date_key = (burst_id, date_str)

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -85,7 +85,7 @@ def run(cfg, burst=None, save_in_scratch=False):
 
         # save SLC to ENVI for all bursts
         # run rdr2geo for only 1 burst avoid redundancy
-        burst.slc_to_file(f'{output_path}/{burst_id}_{date_str}_{pol}.slc')
+        burst.slc_to_file(f'{output_path}/{out_paths.fname_pol}.slc')
 
         # skip burst if id already rdr2geo processed
         # save id if not processed to avoid rdr2geo reprocessing

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -56,9 +56,6 @@ def run(cfg: dict):
         # Get reference burst radar grid
         ref_rdr_grid = cfg.reference_radar_info.grid
 
-        # Extract polarization
-        pol = burst.polarization
-
         # Get radar grid
         rdr_grid = burst.as_isce3_radargrid()
 

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -76,7 +76,7 @@ def run(cfg: dict):
         az_off_raster = isce3.io.Raster(f'{offset_path}/azimuth.off')
 
         # Get original SLC as raster object
-        sec_burst_path = f'{cfg.scratch_path}/{burst_id}_{date_str}_{pol}.slc.vrt'
+        sec_burst_path = f'{out_paths.scratch_directory}/{output_paths.fname_pol}.slc.vrt'
         burst.slc_to_vrt_file(sec_burst_path)
         original_raster = isce3.io.Raster(sec_burst_path)
 

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -73,7 +73,7 @@ def run(cfg: dict):
         az_off_raster = isce3.io.Raster(f'{offset_path}/azimuth.off')
 
         # Get original SLC as raster object
-        sec_burst_path = f'{out_paths.scratch_directory}/{output_paths.fname_pol}.slc.vrt'
+        sec_burst_path = f'{out_paths.scratch_directory}/{out_paths.fname_pol}.slc.vrt'
         burst.slc_to_vrt_file(sec_burst_path)
         original_raster = isce3.io.Raster(sec_burst_path)
 


### PR DESCRIPTION
The PR replaces some leftover f-string path construction with paths generated in runconfig.py to completely address #57.

Note this doesn't replace all f-string paths; only a couple easily replaced ones.