### PR TITLE
Assign static layers product specification version from runconfig

### DIFF
--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -172,8 +172,7 @@ def run(cfg, burst, fetch_from_scratch=False):
         root_group = h5_root[ROOT_PATH]
         metadata_to_h5group(root_group, burst, cfg, save_noise_and_cal=False,
                             save_processing_parameters=False)
-        identity_to_h5group(root_group, burst, cfg, 'Static layers CSLC-S1',
-                            '0.1')
+        identity_to_h5group(root_group, burst, cfg, 'Static layers CSLC-S1')
         algorithm_metadata_to_h5group(root_group, is_static_layers=True)
 
         # Create group static_layers group under DATA_PATH for consistency with

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -247,8 +247,7 @@ def run(cfg: GeoRunConfig):
         t_qa_meta = time.perf_counter()
         with h5py.File(output_hdf5, 'a') as geo_burst_h5:
             root_group = geo_burst_h5[ROOT_PATH]
-            identity_to_h5group(root_group, burst, cfg, 'CSLC -S1',
-                                cfg.product_group.product_specification_version)
+            identity_to_h5group(root_group, burst, cfg, 'CSLC -S1')
 
             metadata_to_h5group(root_group, burst, cfg,
                                 eap_correction_applied=check_eap.phase_correction)

--- a/src/compass/s1_geocode_slc.py
+++ b/src/compass/s1_geocode_slc.py
@@ -247,7 +247,7 @@ def run(cfg: GeoRunConfig):
         t_qa_meta = time.perf_counter()
         with h5py.File(output_hdf5, 'a') as geo_burst_h5:
             root_group = geo_burst_h5[ROOT_PATH]
-            identity_to_h5group(root_group, burst, cfg, 'CSLC -S1')
+            identity_to_h5group(root_group, burst, cfg, 'CSLC-S1')
 
             metadata_to_h5group(root_group, burst, cfg,
                                 eap_correction_applied=check_eap.phase_correction)

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -84,7 +84,7 @@ def run(cfg, burst=None, save_in_scratch=False):
 
         # save SLC to ENVI for all bursts
         # run rdr2geo for only 1 burst avoid redundancy
-        burst.slc_to_file(f'{output_path}/{out_paths.fname_pol}.slc')
+        burst.slc_to_file(f'{output_path}/{out_paths.file_name_pol}.slc')
 
         # skip burst if id already rdr2geo processed
         # save id if not processed to avoid rdr2geo reprocessing

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -379,8 +379,7 @@ def get_polygon_wkt(burst: Sentinel1BurstSlc):
     return geometry_polygon.wkt
 
 
-def identity_to_h5group(dst_group, burst, cfg, product_type,
-                        product_spec_version):
+def identity_to_h5group(dst_group, burst, cfg, product_type):
     '''
     Write burst metadata to HDF5
 
@@ -394,13 +393,12 @@ def identity_to_h5group(dst_group, burst, cfg, product_type,
         Name space dictionary with runconfig parameters
     product_type: str
         Type of COMPASS product
-    product_spec_version: std
-        Product specification of given COMPASS product
+
     '''
     # identification datasets
     id_meta_items = [
         Meta('product_version', f'{cfg.product_group.product_version}', 'CSLC-S1 product version'),
-        Meta('product_specification_version', f'{product_spec_version}',
+        Meta('product_specification_version', f'{cfg.product_group.product_specification_version}',
              'CSLC-S1 product specification version'),
         Meta('absolute_orbit_number', burst.abs_orbit_number, 'Absolute orbit number'),
         Meta('track_number', burst.burst_id.track_number, 'Track number',


### PR DESCRIPTION
This PR allows to assign the product specification version specified in the static layers runconfiguration file to the identification/product_specification_version variable of the CSLC-S1 static layers metadata.

This PR addressed issue #195 