### PR TITLE
Add field for DEM description into runconfig and product

### DIFF
--- a/src/compass/defaults/s1_cslc_geo.yaml
+++ b/src/compass/defaults/s1_cslc_geo.yaml
@@ -17,6 +17,8 @@ runconfig:
       dynamic_ancillary_file_group:
           # Digital elevation model
           dem_file:
+          # Description for DEM used for the processing
+          dem_description: DEM description was not provided.
           # TEC file in IONEX format for ionosphere correction
           tec_file:
           # Troposphere weather model file

--- a/src/compass/schemas/s1_cslc_geo.yaml
+++ b/src/compass/schemas/s1_cslc_geo.yaml
@@ -17,6 +17,8 @@ runconfig:
         dynamic_ancillary_file_group:
            # Digital Elevation Model.
            dem_file: str(required=False)
+           # Description for DEM used for the processing
+           dem_description: str(required=False)
            # TEC file in IONEX format for ionosphere correction
            tec_file: str(required=False)
            # Troposphere weather model

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -519,7 +519,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
              'List of input noise files used for processing'),
         Meta('dem_source',
              os.path.basename(cfg.groups.dynamic_ancillary_file_group.dem_description),
-             'Description for source DEM file'),
+             'Description of the DEM used for processing'),
     ]
     input_group = processing_group.require_group('inputs')
     for meta_item in input_items:

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -510,13 +510,16 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
     # input items
     orbit_files = [os.path.basename(f) for f in cfg.orbit_path]
     input_items = [
-        Meta('l1_slc_files', burst.safe_filename, 'List of input L1 RSLC files used for processing'),
+        Meta('l1_slc_files', burst.safe_filename,
+             'List of input L1 RSLC files used for processing'),
         Meta('orbit_files', orbit_files, 'List of input orbit files used for processing'),
         Meta('calibration_files', burst.burst_calibration.basename_cads,
              'List of input calibration files used for processing'),
         Meta('noise_files', burst.burst_noise.basename_nads,
              'List of input noise files used for processing'),
-        Meta('dem_source', os.path.basename(cfg.dem), 'source DEM file'),
+        Meta('dem_source',
+             os.path.basename(cfg.groups.dynamic_ancillary_file_group.dem_description),
+             'Description for source DEM file'),
     ]
     input_group = processing_group.require_group('inputs')
     for meta_item in input_items:

--- a/tests/test_s1_geocode_slc.py
+++ b/tests/test_s1_geocode_slc.py
@@ -120,3 +120,9 @@ def test_geocode_slc_validate(geocode_slc_params):
     # check for bright spots in sliced array
     corner_reflector_threshold = 3e3
     assert np.any(np.abs(arr) > corner_reflector_threshold)
+
+
+def test_metadata(geocode_slc_params):
+    with h5py.File(geocode_slc_params.output_hdf5_path, 'r') as h5_obj:
+        assert (h5_obj['/metadata/processing_information/inputs/dem_source'][()].decode() ==
+                'DEM description was not provided.')


### PR DESCRIPTION
This PR adds a field for DEM description into runconfig and the output product.
The field `dem_description` will be populated into `/metadata/processing_information/inputs/dem_source`, which was previously being populated with the filename of the DEM i.e. `dem_file`.