### PR TITLE
add `conda clean -afy` after install for smaller image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,8 @@ RUN ${CONDA_PREFIX}/bin/conda init bash
 COPY --chown=compass_user:compass_user . /home/compass_user/OPERA/COMPASS
 
 # create CONDA environment
-RUN conda create --name "COMPASS" --file /home/compass_user/OPERA/COMPASS/docker/specfile.txt
+RUN conda create --name "COMPASS" --file /home/compass_user/OPERA/COMPASS/docker/specfile.txt \
+    && conda clean -afy
 
 SHELL ["conda", "run", "-n", "COMPASS", "/bin/bash", "-c"]
 


### PR DESCRIPTION
drops size by 1 GB