### PR TITLE
set `gdal.UseExceptions` so that `open_raster` throws `RuntimeError`

### DIFF
--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -15,6 +15,7 @@ from shapely import geometry
 
 import compass
 
+gdal.UseExceptions()
 
 WORKFLOW_SCRIPTS_DIR = os.path.dirname(compass.__file__)
 OPERA_OPERATION_CONTACT_EMAIL = 'opera-sds-ops@jpl.nasa.gov'
@@ -351,7 +352,7 @@ def open_raster(filename, band=1):
         ds = gdal.Open(filename, gdal.GA_ReadOnly)
         arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
-    except AttributeError:
+    except RuntimeError:
         # GDAL reads 1st 2 bytes of ENVI binary to determine file type. If 1st
         # bytes of flat binary is that of a jpeg but the binary is not then
         # GDAL throws a libjpeg runtime error. Follow specifically tries to


### PR DESCRIPTION
Another option to fix #206
Right now an attribute error gets thrown only if no code has called `UseExceptions`.
Feel free to merge or ignore this if you wanna fix in a different way.