### PR TITLE
Missing polygon, fake jpeg, and turning off azimuth FM rate

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM oraclelinux:8
+FROM oraclelinux:8.8
 
 LABEL author="OPERA ADT" \
-    description="s1 cslc 0.3.2 point release" \
-    version="0.3.2-point"
+    description="s1 cslc 0.5.3 point release" \
+    version="0.5.3-point"
 
 # Update the base linux image to date
 # Create cache and config directory to be used for the dependencies

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -545,13 +545,6 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
     for meta_item in vrt_items:
         add_dataset_and_attrs(vrt_group, meta_item)
 
-    # Fill in the center coordinated with NaN when
-    # the burst does not have center point information
-    if burst.center.is_empty:
-        xy_center = [float('nan')] * 2
-    else:
-        xy_center = [xy[0] for xy in burst.center.coords.xy]
-        
     # burst items
     burst_meta_items = [
         Meta('ipf_version', str(burst.ipf_version),
@@ -594,7 +587,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
         Meta('polarization', burst.polarization, 'Polarization of the burst'),
         Meta('platform_id', burst.platform_id,
              'Sensor platform identification string (e.g., S1A or S1B)'),
-        Meta('center', xy_center,
+        Meta('center', [xy[0] for xy in burst.center.coords.xy],
              'Longitude, latitude center of burst', {'units':'degrees'}),
         # window parameters
         Meta('range_window_type', burst.range_window_type,
@@ -614,7 +607,6 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
         add_dataset_and_attrs(burst_meta_group, meta_item)
 
     # Add parameters group in processing information
-    flag_set_applied = not burst.border[0].is_empty
     if save_processing_parameters:
         dry_tropo_corr_enabled = \
             True if (cfg.weather_model_file is not None) and \
@@ -646,7 +638,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
             Meta('geometry_doppler_applied',
                  bool(cfg.lut_params.enabled),
                  "If True, geometry steering doppler timing correction has been applied"),
-            Meta('los_solid_earth_tides_applied', bool(flag_set_applied),
+            Meta('los_solid_earth_tides_applied', bool(cfg.lut_params.enabled),
                  "If True, solid Earth tides correction has been applied in slant range direction"),
             Meta('azimuth_solid_earth_tides_applied', False,
                  "If True, solid Earth tides correction has been applied in azimuth direction"),

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -545,6 +545,13 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
     for meta_item in vrt_items:
         add_dataset_and_attrs(vrt_group, meta_item)
 
+    # Fill in the center coordinated with NaN when
+    # the burst does not have center point information
+    if burst.center.is_empty:
+        xy_center = [float('nan')] * 2
+    else:
+        xy_center = [xy[0] for xy in burst.center.coords.xy]
+        
     # burst items
     burst_meta_items = [
         Meta('ipf_version', str(burst.ipf_version),
@@ -587,7 +594,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
         Meta('polarization', burst.polarization, 'Polarization of the burst'),
         Meta('platform_id', burst.platform_id,
              'Sensor platform identification string (e.g., S1A or S1B)'),
-        Meta('center', [xy[0] for xy in burst.center.coords.xy],
+        Meta('center', xy_center,
              'Longitude, latitude center of burst', {'units':'degrees'}),
         # window parameters
         Meta('range_window_type', burst.range_window_type,
@@ -607,6 +614,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
         add_dataset_and_attrs(burst_meta_group, meta_item)
 
     # Add parameters group in processing information
+    flag_set_applied = not burst.border[0].is_empty
     if save_processing_parameters:
         dry_tropo_corr_enabled = \
             True if (cfg.weather_model_file is not None) and \
@@ -638,7 +646,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
             Meta('geometry_doppler_applied',
                  bool(cfg.lut_params.enabled),
                  "If True, geometry steering doppler timing correction has been applied"),
-            Meta('los_solid_earth_tides_applied', bool(cfg.lut_params.enabled),
+            Meta('los_solid_earth_tides_applied', bool(flag_set_applied),
                  "If True, solid Earth tides correction has been applied in slant range direction"),
             Meta('azimuth_solid_earth_tides_applied', False,
                  "If True, solid Earth tides correction has been applied in azimuth direction"),

--- a/src/compass/utils/h5_helpers.py
+++ b/src/compass/utils/h5_helpers.py
@@ -633,7 +633,7 @@ def metadata_to_h5group(parent_group, burst, cfg, save_noise_and_cal=True,
                  bool(cfg.lut_params.enabled),
                  "If True, bistatic delay timing correction has been applied"),
             Meta('azimuth_fm_rate_applied',
-                 bool(cfg.lut_params.enabled),
+                 False,  # NOTE: Azimuth FM rate was turned off for OPERA production
                  "If True, azimuth FM-rate mismatch timing correction has been applied"),
             Meta('geometry_doppler_applied',
                  bool(cfg.lut_params.enabled),

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -348,10 +348,17 @@ def open_raster(filename, band=1):
         raise FileNotFoundError(err_str)
 
     try:
+        # The pythonic execption handling for GDAL can be turned on / off
+        # The flag of which can be identified by `gdal.GetUseExceptions()`
+        # In pythonic exception halding, `gdal.Open()` will raise `RuntimeError`
+        # In traditional GDAL, the function does not raise exception buy will return `None`,
+        # and the attempts to call GDAL methods will raise `AttributeError`
+
         ds = gdal.Open(filename, gdal.GA_ReadOnly)
         arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
-    except AttributeError:
+
+    except (AttributeError, RuntimeError):
         # GDAL reads 1st 2 bytes of ENVI binary to determine file type. If 1st
         # bytes of flat binary is that of a jpeg but the binary is not then
         # GDAL throws a libjpeg runtime error. Follow specifically tries to

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -358,7 +358,7 @@ def open_raster(filename, band=1):
         arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
 
-    except (AttributeError, RuntimeError):
+    except:
         # GDAL reads 1st 2 bytes of ENVI binary to determine file type. If 1st
         # bytes of flat binary is that of a jpeg but the binary is not then
         # GDAL throws a libjpeg runtime error. Follow specifically tries to

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -358,7 +358,7 @@ def open_raster(filename, band=1):
         arr = ds.GetRasterBand(band).ReadAsArray()
         return arr
 
-    except:
+    except Exception:
         # GDAL reads 1st 2 bytes of ENVI binary to determine file type. If 1st
         # bytes of flat binary is that of a jpeg but the binary is not then
         # GDAL throws a libjpeg runtime error. Follow specifically tries to

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -81,7 +81,7 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
 
     # Invert signs to correct for convention
     #az_lut_data = -(bistatic_delay.data + az_fm_mismatch.data)
-    az_lut_data = -(bistatic_delay.data)
+    az_lut_data = -bistatic_delay.data
     # NOTE: Azimuth FM rate was turned off for OPERA production
 
     rg_lut = isce3.core.LUT2d(bistatic_delay.x_start,

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -229,13 +229,17 @@ def compute_geocoding_correction_luts(burst, dem_path, tec_path,
                                                  height[dec_slice],
                                                  ellipsoid,
                                                  geo2rdr_params)
-
-    # Resize SET to the size of the correction grid
     out_shape = bistatic_delay.data.shape
-    kwargs = dict(order=1, mode='edge', anti_aliasing=True,
-                  preserve_range=True)
-    rg_set = resize(rg_set_temp, out_shape, **kwargs)
-    az_set = resize(az_set_temp, out_shape, **kwargs)
+    # Return zero-filled array when `solid_earth_tides` is not successful
+    if (rg_set_temp is None)  and (az_set_temp is None):
+        rg_set = np.zeros(out_shape)
+        az_set = np.zeros(out_shape)
+    else:
+        # Resize SET to the size of the correction grid    
+        kwargs = dict(order=1, mode='edge', anti_aliasing=True,
+                      preserve_range=True)
+        rg_set = resize(rg_set_temp, out_shape, **kwargs)
+        az_set = resize(az_set_temp, out_shape, **kwargs)
 
     # Compute ionosphere delay
     los_ionosphere = ionosphere_delay(burst.sensing_mid,
@@ -307,6 +311,10 @@ def solid_earth_tides(burst, lat_radar_grid, lon_radar_grid, hgt_radar_grid,
     '''
 
     # Extract top-left coordinates from burst polygon
+    if burst.border[0].is_empty:
+        # Return `None` when the corner coordinates cannot be extracted
+        return None, None
+
     lon_min, lat_min, _, _ = burst.border[0].bounds
 
     # Generate the atr object to run pySolid. We compute SET on a

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -230,16 +230,10 @@ def compute_geocoding_correction_luts(burst, dem_path, tec_path,
                                                  ellipsoid,
                                                  geo2rdr_params)
     out_shape = bistatic_delay.data.shape
-    # Return zero-filled array when `solid_earth_tides` is not successful
-    if (rg_set_temp is None)  and (az_set_temp is None):
-        rg_set = np.zeros(out_shape)
-        az_set = np.zeros(out_shape)
-    else:
-        # Resize SET to the size of the correction grid    
-        kwargs = dict(order=1, mode='edge', anti_aliasing=True,
-                      preserve_range=True)
-        rg_set = resize(rg_set_temp, out_shape, **kwargs)
-        az_set = resize(az_set_temp, out_shape, **kwargs)
+    kwargs = dict(order=1, mode='edge', anti_aliasing=True,
+                    preserve_range=True)
+    rg_set = resize(rg_set_temp, out_shape, **kwargs)
+    az_set = resize(az_set_temp, out_shape, **kwargs)
 
     # Compute ionosphere delay
     los_ionosphere = ionosphere_delay(burst.sensing_mid,
@@ -311,10 +305,6 @@ def solid_earth_tides(burst, lat_radar_grid, lon_radar_grid, hgt_radar_grid,
     '''
 
     # Extract top-left coordinates from burst polygon
-    if burst.border[0].is_empty:
-        # Return `None` when the corner coordinates cannot be extracted
-        return None, None
-
     lon_min, lat_min, _, _ = burst.border[0].bounds
 
     # Generate the atr object to run pySolid. We compute SET on a

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -80,8 +80,9 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
         rg_lut_data += dry_los_tropo
 
     # Invert signs to correct for convention
-    # TO DO: add azimuth SET to LUT
-    az_lut_data = -(bistatic_delay.data + az_fm_mismatch.data)
+    #az_lut_data = -(bistatic_delay.data + az_fm_mismatch.data)
+    az_lut_data = -(bistatic_delay.data)
+    # NOTE: Azimuth FM rate was turned off for OPERA production
 
     rg_lut = isce3.core.LUT2d(bistatic_delay.x_start,
                               bistatic_delay.y_start,

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,6 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.5.2', '2023-10-04'),
     Tag('0.5.1', '2023-09-09'),
     Tag('0.5.0', '2023-08-25'),
     Tag('0.4.1', '2023-08-14'),

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,7 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
-    Tag('0.5.2', '2023-10-04'),
+    Tag('0.5.3', '2023-10-05'),
     Tag('0.5.1', '2023-09-09'),
     Tag('0.5.0', '2023-08-25'),
     Tag('0.4.1', '2023-08-14'),


### PR DESCRIPTION
This PR is an attempt to fix the issues triaged by the test by SDS.
- When the bursts's polygon is missing, the SET will be turned off. Also the center point in the metadata will be populated as [`NaN`, `NaN`]
- Unpredictable behavior was discovered from GDAL regarding error handling. Depending on GDAL's error handling mode, The fake JPEG issue will raise an error on either from `gdal.Open()`, or when attempting to access GDAL methods from `None`. The fix captures both types of error, and takes care of that.

EDIT:
- the missing polygon issue will stay as it is, so that the job gets failed
- Azimuth FM rate fill be turned off for OPERA production
