### PR TITLE
Add azimuth FM rate into azimuth timing correction LUT

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,6 @@ RUN mkdir RAiDER &&\
     python -m pip install ./RAiDER &&\
     rm -rf RAiDER
 
-
 # installing OPERA COMPASS
 RUN python -m pip install ./COMPASS &&\
     echo "conda activate COMPASS" >> /home/compass_user/.bashrc

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -80,9 +80,7 @@ def cumulative_correction_luts(burst, dem_path, tec_path,
         rg_lut_data += dry_los_tropo
 
     # Invert signs to correct for convention
-    #az_lut_data = -(bistatic_delay.data + az_fm_mismatch.data)
-    az_lut_data = -bistatic_delay.data
-    # NOTE: Azimuth FM rate was turned off for OPERA production
+    az_lut_data = -(bistatic_delay.data + az_fm_mismatch.data)
 
     rg_lut = isce3.core.LUT2d(bistatic_delay.x_start,
                               bistatic_delay.y_start,

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,6 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.5.4', '2023-10-13'),
     Tag('0.5.3', '2023-10-05'),
     Tag('0.5.2', '2023-09-21'),
     Tag('0.5.1', '2023-09-09'),


### PR DESCRIPTION
This PR is to prepare for the 3rd final point release to turn the azimuth FM rate correction `ON`, and fix the GDAL error when loading ENVI file.
Please note that the version has bumped from `0.5.3` to `0.5.4`, and `0.5.3` was not delivered to SDS.
In `0.5.3`, azimuth FM rate was turned `OFF`, and gdal issue was fixed. In this PR, the azimuth FM rate is applied again, therefore, compared to the most recent delivery (i.e. `0.5.2`), this PR only addresses the GDAL issue.