### PR TITLE
Patch release 240315

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: check-added-large-files

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+REPO=opera
+IMAGE=cslc_s1
+TAG=final_0.5.5
+
+echo "IMAGE is $REPO/$IMAGE:$TAG"
+
+rm docker/dockerimg_cslc_s1_${TAG}.tar
+
+# fail on any non-zero exit codes
+set -ex
+
+docker build --rm --force-rm --network host -t $REPO/$IMAGE:$TAG -f docker/Dockerfile.isce3_builder .
+
+docker save $REPO/$IMAGE:$TAG > docker/dockerimg_cslc_s1_${TAG}.tar

--- a/docker/Dockerfile.isce3_builder
+++ b/docker/Dockerfile.isce3_builder
@@ -44,7 +44,7 @@ SHELL ["conda", "run", "-n", "COMPASS", "/bin/bash", "-c"]
 RUN mkdir -p /home/compass_user/OPERA/ISCE3/install &&\
     mkdir -p /home/compass_user/OPERA/ISCE3/build &&\
     cd /home/compass_user/OPERA/ISCE3 &&\
-    curl -sSL https://github.com/isce-framework/isce3/archive/refs/tags/v0.14.0.zip -o isce3_sourcecode.zip &&\
+    curl -sSL https://github.com/isce-framework/isce3/archive/refs/tags/v0.15.1.zip -o isce3_sourcecode.zip &&\
     unzip isce3_sourcecode.zip &&\
     rm isce3_sourcecode.zip &&\
     cd /home/compass_user/OPERA/ISCE3/build &&\

--- a/docker/Dockerfile.isce3_builder
+++ b/docker/Dockerfile.isce3_builder
@@ -7,8 +7,8 @@
 FROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
-    description="s1 cslc 0.3.2 point release" \
-    version="0.3.2-point"
+    description="s1 cslc 0.5.5 patch release" \
+    version="0.5.5-final_point"
 
 RUN yum -y update &&\
     yum -y install curl git make unzip &&\
@@ -48,7 +48,7 @@ RUN mkdir -p /home/compass_user/OPERA/ISCE3/install &&\
     unzip isce3_sourcecode.zip &&\
     rm isce3_sourcecode.zip &&\
     cd /home/compass_user/OPERA/ISCE3/build &&\
-    cmake -DCMAKE_INSTALL_PREFIX=/home/compass_user/OPERA/ISCE3/install -DWITH_CUDA=OFF /home/compass_user/OPERA/ISCE3/isce3-0.14.0 &&\
+    cmake -DCMAKE_INSTALL_PREFIX=/home/compass_user/OPERA/ISCE3/install -DWITH_CUDA=OFF -DCMAKE_BUILD_TYPE=Release /home/compass_user/OPERA/ISCE3/isce3-0.15.1 &&\
     make -j32 VERBOSE=ON &&\
     make install &&\
     rm -rf /home/compass_user/OPERA/ISCE3/build/* &&\
@@ -56,7 +56,7 @@ RUN mkdir -p /home/compass_user/OPERA/ISCE3/install &&\
     find /home/compass_user/OPERA/ISCE3/install/lib64 -name "*.so*" -exec ln -s {} \; &&\
     cd `find $CONDA_PREFIX -name "site-packages"|sort|tail -1` &&\
     find /home/compass_user/OPERA/ISCE3/install/packages -maxdepth 1 -type d|sort|awk 'NR>1'|xargs -I{} ln -s {} &&\
-    rm -rf /home/compass_user/OPERA/ISCE3/isce3-0.14.0 &&\
+    rm -rf /home/compass_user/OPERA/ISCE3/isce3-0.15.1 &&\
     rm -rf /home/compass_user/OPERA/ISCE3/build
 
 WORKDIR /home/compass_user/OPERA
@@ -64,9 +64,9 @@ WORKDIR /home/compass_user/OPERA
 
 
 # installing OPERA s1-reader
-RUN curl -sSL https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.1.7.tar.gz -o s1_reader_src.tar.gz &&\
+RUN curl -sSL https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.2.4.tar.gz -o s1_reader_src.tar.gz &&\
     tar -xvf s1_reader_src.tar.gz &&\
-    ln -s s1-reader-0.1.7 s1-reader &&\
+    ln -s s1-reader-0.2.4 s1-reader &&\
     rm s1_reader_src.tar.gz &&\
     python -m pip install ./s1-reader
 

--- a/docker/build_docker_image.sh
+++ b/docker/build_docker_image.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-
-TAG = opera/cslc_s1:calval_0.3
-
-docker build --rm --force-rm --network host -t $TAG -f docker/Dockerfile .

--- a/src/compass/version.py
+++ b/src/compass/version.py
@@ -8,6 +8,7 @@ import collections
 # release history
 Tag = collections.namedtuple('Tag', 'version date')
 release_history = (
+    Tag('0.5.5', '2024-03-15'),
     Tag('0.5.4', '2023-10-13'),
     Tag('0.5.3', '2023-10-05'),
     Tag('0.5.2', '2023-09-21'),


### PR DESCRIPTION
This PR does not change the core of COMPASS, but updates the Docker file and bump the version for the patch release. The biggest change in terms of the SAS deliverables is that the ISCE3 will be built from source code, rather than using the conda package.