### PR TITLE
Fixing typos for `s1_cslc_radar` and `s1_resample`

### DIFF
--- a/src/compass/defaults/s1_cslc_radar.yaml
+++ b/src/compass/defaults/s1_cslc_radar.yaml
@@ -61,6 +61,8 @@ runconfig:
                compute_local_incidence_angle: False
                # Enable/disable azimuth angle output
                compute_azimuth_angle: False
+               compute_ground_to_sat_east: False
+               compute_ground_to_sat_north: False
            geo2rdr:
                lines_per_block: 1000
                threshold: 1.0e-8

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -73,7 +73,7 @@ def run(cfg: dict):
         az_off_raster = isce3.io.Raster(f'{offset_path}/azimuth.off')
 
         # Get original SLC as raster object
-        sec_burst_path = f'{out_paths.scratch_directory}/{out_paths.fname_pol}.slc.vrt'
+        sec_burst_path = f'{out_paths.scratch_directory}/{out_paths.file_name_pol}.slc.vrt'
         burst.slc_to_vrt_file(sec_burst_path)
         original_raster = isce3.io.Raster(sec_burst_path)
 

--- a/src/compass/schemas/s1_cslc_radar.yaml
+++ b/src/compass/schemas/s1_cslc_radar.yaml
@@ -78,6 +78,8 @@ rdr2geo_options:
    compute_local_incidence_angle: bool(required=False)
    # Enable/disable azimuth angle output
    compute_azimuth_angle: bool(required=False)
+   compute_ground_to_sat_east: bool(required=False)
+   compute_ground_to_sat_north: bool(required=False)
 
 resample_options:
    # Lines per block to process in batch

--- a/src/compass/utils/runconfig.py
+++ b/src/compass/utils/runconfig.py
@@ -374,8 +374,7 @@ class RunConfig:
         ref_rdr_grid_info = None
         if not sns.input_file_group.reference_burst.is_reference:
             ref_rdr_grid_info = get_ref_radar_grid_info(
-                sns.input_file_group.reference_burst.file_path,
-                sns.input_file_group.burst_id)
+                sns.input_file_group.reference_burst.file_path)
 
         # For saving entire file with defaults filled-in as string to metadata.
         # Stop gap for writing dict to individual elements to HDF5 metadata


### PR DESCRIPTION
This PR is to add the `compute_ground_to_sat_east` and `compute_ground_to_sat_north` options in the yaml schema and to fix few typos in the s1_resample.py and utils/runconfig.py for the cslc workflow.