### PR TITLE
Fix intermediate raster format

### DIFF
--- a/src/compass/s1_cslc.py
+++ b/src/compass/s1_cslc.py
@@ -37,7 +37,7 @@ def run(run_config_path: str, grid_type: str):
 
     elif grid_type == 'geo':
         # CSLC workflow in geo-coordinates
-        # get a runconfig dict from command line argumens
+        # get a runconfig dict from command line arguments
         cfg = GeoRunConfig.load_from_yaml(run_config_path, 's1_cslc_geo')
 
         # Check if product_type is CSLC-S1, and produce product only

--- a/src/compass/s1_cslc_qa.py
+++ b/src/compass/s1_cslc_qa.py
@@ -640,7 +640,7 @@ def _get_land_mask(epsg_cslc: int, geotransform: tuple, shape_mask: tuple):
     feature = layer_land.GetNextFeature()
     land_polygon = feature.GetGeometryRef()
 
-    # extract the EPSG of the land polgyon GPKG
+    # extract the EPSG of the land polygon GPKG
     srs_gpkg = layer_land.GetSpatialRef()
     land_epsg = int(srs_gpkg.GetAuthorityCode(None))
 

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -206,7 +206,7 @@ def run(cfg, burst, fetch_from_scratch=False):
             output_raster = isce3.io.Raster(f"IH5:::ID={topo_ds.id.id}".encode("utf-8"),
                                             update=True)
 
-            input_raster = isce3.io.Raster(f'{input_path}/{raster_file_name}.rdr')
+            input_raster = isce3.io.Raster(f'{input_path}/{raster_file_name}.tif')
 
             geocode_obj.geocode(radar_grid=radar_grid,
                                 input_raster=input_raster,
@@ -355,7 +355,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
         lut_arr = np.matmul(azimuth_lut_interp[..., np.newaxis],
                             range_lut_interp[np.newaxis, ...])
 
-        lut_path = f'{scratch_path}/{item_name}_radargrid.rdr'
+        lut_path = f'{scratch_path}/{item_name}_radargrid.tif'
         lut_gdal_raster = gdal_geotiff_driver.Create(lut_path,
                                                   radargrid_interp.width,
                                                   radargrid_interp.length,

--- a/src/compass/s1_geocode_metadata.py
+++ b/src/compass/s1_geocode_metadata.py
@@ -306,7 +306,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
     dst_group =\
         geo_burst_h5.require_group(dst_group_path)
 
-    gdal_envi_driver = gdal.GetDriverByName('ENVI')
+    gdal_geotiff_driver = gdal.GetDriverByName('GTiff')
 
     # Define the radargrid for LUT interpolation
     # The resultant radargrid will have
@@ -356,7 +356,7 @@ def geocode_luts(geo_burst_h5, burst, cfg, dst_group_path, item_dict,
                             range_lut_interp[np.newaxis, ...])
 
         lut_path = f'{scratch_path}/{item_name}_radargrid.rdr'
-        lut_gdal_raster = gdal_envi_driver.Create(lut_path,
+        lut_gdal_raster = gdal_geotiff_driver.Create(lut_path,
                                                   radargrid_interp.width,
                                                   radargrid_interp.length,
                                                   1, gdal.GDT_Float32)

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -128,7 +128,7 @@ def run(cfg, burst=None, save_in_scratch=False):
                        rdr2geo_cfg.compute_ground_to_sat_north, gdal.GDT_Float32),
                        }
         raster_list = [
-            isce3.io.Raster(f'{output_path}/{fname}.rdr', rdr_grid.width,
+            isce3.io.Raster(f'{output_path}/{fname}.tif', rdr_grid.width,
                             rdr_grid.length, 1, dtype, 'GTiff')
             if enabled else None
             for fname, (enabled, dtype) in topo_output.items()]

--- a/src/compass/s1_rdr2geo.py
+++ b/src/compass/s1_rdr2geo.py
@@ -82,9 +82,9 @@ def run(cfg, burst=None, save_in_scratch=False):
         if save_in_scratch:
             output_path = out_paths.scratch_directory
 
-        # save SLC to ENVI for all bursts
+        # save SLC to Geotiff for all bursts
         # run rdr2geo for only 1 burst avoid redundancy
-        burst.slc_to_file(f'{output_path}/{out_paths.file_name_pol}.slc')
+        burst.slc_to_file(f'{output_path}/{out_paths.file_name_pol}.slc.tif', 'GTiff')
 
         # skip burst if id already rdr2geo processed
         # save id if not processed to avoid rdr2geo reprocessing
@@ -129,7 +129,7 @@ def run(cfg, burst=None, save_in_scratch=False):
                        }
         raster_list = [
             isce3.io.Raster(f'{output_path}/{fname}.rdr', rdr_grid.width,
-                            rdr_grid.length, 1, dtype, 'ENVI')
+                            rdr_grid.length, 1, dtype, 'GTiff')
             if enabled else None
             for fname, (enabled, dtype) in topo_output.items()]
 

--- a/src/compass/s1_resample.py
+++ b/src/compass/s1_resample.py
@@ -78,12 +78,12 @@ def run(cfg: dict):
         original_raster = isce3.io.Raster(sec_burst_path)
 
         # Prepare resampled SLC as raster object
-        coreg_burst_path = f'{out_paths.output_directory}/{out_paths.file_name_stem}.slc'
+        coreg_burst_path = f'{out_paths.output_directory}/{out_paths.file_name_stem}.slc.tif'
         resampled_raster = isce3.io.Raster(coreg_burst_path,
                                            rg_off_raster.width,
                                            rg_off_raster.length,
                                            1, gdal.GDT_CFloat32,
-                                           'ENVI')
+                                           'GTiff')
 
         resamp_obj.resamp(original_raster, resampled_raster,
                           rg_off_raster, az_off_raster,

--- a/src/compass/utils/elevation_antenna_pattern.py
+++ b/src/compass/utils/elevation_antenna_pattern.py
@@ -20,7 +20,7 @@ def apply_eap_correction(burst, path_slc_vrt, path_slc_corrected, check_eap):
     path_slc_corrected: str:
         Path to the burst SLC after EAP correction
     check_eap: Namespace
-        A namespace that contains flags if phase and/or magnitute
+        A namespace that contains flags if phase and/or magnitude
         EAP correction are necessary
 
     '''
@@ -45,7 +45,7 @@ def apply_eap_correction(burst, path_slc_vrt, path_slc_corrected, check_eap):
 
     # Write out the EAP-corrected SLC
     dtype = slc_in.GetRasterBand(1).DataType
-    drvout = gdal.GetDriverByName('ENVI')
+    drvout = gdal.GetDriverByName('GTiff')
     raster_out = drvout.Create(path_slc_corrected, burst.shape[1],
                                burst.shape[0], 1, dtype)
     band_out = raster_out.GetRasterBand(1)

--- a/src/compass/utils/geometry_utils.py
+++ b/src/compass/utils/geometry_utils.py
@@ -300,7 +300,7 @@ def enu2rgaz(radargrid_ref, orbit, ellipsoid,
         Orbit of the burst
     ellipsoid: isce3.core.Ellipsoid
         Ellipsoid definition
-    lon_arr, lat_arr, hgt_arr: np.nadrray
+    lon_arr, lat_arr, hgt_arr: np.ndarray
         Arrays for longitude, latitude, and height.
         Units for longitude and latitude are degree; unit for height is meters.
     e_arr, n_arr, u_arr: np.ndarray

--- a/src/compass/utils/geometry_utils.py
+++ b/src/compass/utils/geometry_utils.py
@@ -37,7 +37,7 @@ def los2orbit_azimuth_angle(los_az_angle, look_direction='right'):
 
 def azimuth2heading_angle(az_angle, look_direction='right'):
     """
-    Convert azimuth angle from ISCE los.rdr band2 into satellite orbit heading angle
+    Convert azimuth angle from ISCE los.tif band2 into satellite orbit heading angle
     ISCE-2 los.* file band2 is azimuth angle of LOS vector from ground target to the satellite
     measured from the north in anti-clockwise as positive.
 
@@ -49,7 +49,7 @@ def azimuth2heading_angle(az_angle, look_direction='right'):
     ----------
     az_angle: np.ndarray or float
         Measured from North in anti-clockwise direction. Same definition
-        as ISCE2 azimmuth angle (second band of *los raster)
+        as ISCE2 azimuth angle (second band of *los raster)
     look_direction: str
         Satellite look direction. S1-A/B is right; NISAR is left
 

--- a/src/compass/utils/helpers.py
+++ b/src/compass/utils/helpers.py
@@ -348,7 +348,7 @@ def open_raster(filename, band=1):
         raise FileNotFoundError(err_str)
 
     try:
-        # The pythonic execption handling for GDAL can be turned on / off
+        # The pythonic exception handling for GDAL can be turned on / off
         # The flag of which can be identified by `gdal.GetUseExceptions()`
         # In pythonic exception handling, `gdal.Open()` will raise `RuntimeError`
         # In traditional GDAL, the function does not raise exception buy will return `None`,
@@ -370,7 +370,7 @@ def open_raster(filename, band=1):
 
 
 def write_raster(filename, data_list, descriptions,
-                 data_type=gdal.GDT_Float32, data_format='ENVI'):
+                 data_type=gdal.GDT_Float32, data_format='GTiff'):
     '''
     Write a multiband GDAL-friendly raster to disk.
     Each dataset allocated in the output file contains

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -292,7 +292,7 @@ def solid_earth_tides(burst, lat_radar_grid, lon_radar_grid, hgt_radar_grid,
         Longitude array on burst radargrid
     inc_angle: np.ndarray
         Incident angle raster in unit of degrees
-    head_angle: np.ndaaray
+    head_angle: np.ndarray
         Heading angle raster in unit of degrees
 
     Returns
@@ -458,7 +458,7 @@ def compute_static_troposphere_delay(incidence_angle_arr, hgt_arr):
     inc_path: str
         Path to incidence angle raster in radar grid in degrees
     hgt_path: str
-        Path to surface heightraster in radar grid in meters
+        Path to surface height raster in radar grid in meters
 
     Return:
     -------

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -400,11 +400,11 @@ def compute_rdr2geo_rasters(burst, dem_raster, output_path,
                                          threshold=1.0e-8)
 
     # Get the rdr2geo raster needed for SET computation
-    topo_output = {f'{output_path}/x.rdr': gdal.GDT_Float64,
-                   f'{output_path}/y.rdr': gdal.GDT_Float64,
-                   f'{output_path}/height.rdr': gdal.GDT_Float64,
-                   f'{output_path}/incidence_angle.rdr': gdal.GDT_Float32,
-                   f'{output_path}/heading_angle.rdr': gdal.GDT_Float32}
+    topo_output = {f'{output_path}/x.tif': gdal.GDT_Float64,
+                   f'{output_path}/y.tif': gdal.GDT_Float64,
+                   f'{output_path}/height.tif': gdal.GDT_Float64,
+                   f'{output_path}/incidence_angle.tif': gdal.GDT_Float32,
+                   f'{output_path}/heading_angle.tif': gdal.GDT_Float32}
     raster_list = [
         isce3.io.Raster(fname, rdr_grid.width,
                         rdr_grid.length, 1, dtype, 'GTiff')

--- a/src/compass/utils/lut.py
+++ b/src/compass/utils/lut.py
@@ -407,7 +407,7 @@ def compute_rdr2geo_rasters(burst, dem_raster, output_path,
                    f'{output_path}/heading_angle.rdr': gdal.GDT_Float32}
     raster_list = [
         isce3.io.Raster(fname, rdr_grid.width,
-                        rdr_grid.length, 1, dtype, 'ENVI')
+                        rdr_grid.length, 1, dtype, 'GTiff')
         for fname, dtype in topo_output.items()]
     x_raster, y_raster, height_raster, incidence_raster, heading_raster = raster_list
 

--- a/src/compass/utils/range_split_spectrum.py
+++ b/src/compass/utils/range_split_spectrum.py
@@ -39,7 +39,7 @@ def range_split_spectrum(burst,
     burst_path: str
         Path to the burst SLC to apply split spectrum
     cfg_split_spectrum: dict
-        Dictionary with split-spetrum options
+        Dictionary with split-spectrum options
     scratch_path: str
         Directory for storing temp files
 
@@ -87,8 +87,8 @@ def range_split_spectrum(burst,
     # contain 3 bands: Band #1: low-band image; Band #2 main-band image;
     # Band #3: high-band image.
     in_ds = gdal.Open(burst_path, gdal.GA_ReadOnly)
-    driver = gdal.GetDriverByName('ENVI')
-    out_ds = driver.Create(f'{scratch_path}/{burst_id_pol}_low_main_high.slc',
+    driver = gdal.GetDriverByName('GTiff')
+    out_ds = driver.Create(f'{scratch_path}/{burst_id_pol}_low_main_high.slc.tif',
                            width, length, 3, gdal.GDT_CFloat32)
 
     # Prepare necessary variables for block processing


### PR DESCRIPTION
This PR is for fixing the SAS failure reported by the SDS team in November 2024. The reason for the failure was because in rare case GDAL did not recognize the intermediate raster files written in ENVI format. The fix was to change their format from ENVI to Geotiff.

The change was tested by processing the two cases of triaged dataset from PGE, which were successful. Also the old CSLC products were re-processed with the fixed COMPASS, and they are compared by using [validate_product.py](https://github.com/opera-adt/COMPASS/blob/main/src/compass/utils/validate_product.py). The comparison did not catch any differences between them.

The increase of the speed was also tested. A slight increase in the processing time was noticed.

Burst CSLC: 
- before: 1 minutes 05 seconds
- after: 1 minutes 06 seconds

Static layer:
- before: 2 minutes 03 seconds
- after: 2 minutes 15 seconds
